### PR TITLE
Term improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Only the marked dependencies will be considered by MrAnderson.
 
 Then run
 
-    $ lein source-deps
+    $ lein inline-deps
 
 This retrieves and modifies the marked dependencies and copies them to `target/srcdeps` together with the modified project files -- their references to the dependencies need to change too.
 
@@ -181,7 +181,7 @@ To use the **unresolved tree** mode you can either provide a flag in the above m
 
 or you can provide the same flag on the command line:
 
-    $ lein source-deps :unresolved-tree true
+    $ lein inline-deps :unresolved-tree true
 
 The latter supersedes the former.
 
@@ -191,11 +191,11 @@ Again: in the **resolved tree** mode no transient dependency hygiene is applied.
 
 | Option                   | Default                        | CLI or project.clj    | Description | Example |
 |--------------------------|--------------------------------|-----------------------|-------------|---------|
-| project-prefix           | mranderson{rnd}                | CLI                   | project pecific prefix to use when shadowing            | `lein source-deps :project-prefix cider.inlined-deps` |
-| skip-javaclass-repackage | false                          | CLI                   | If true [Jar Jar Links](https://code.google.com/p/jarjar/) won't be used to repackage java classes in dependencies            | `lein source-deps :skip-javaclass-repackage true`        |
-| prefix-exclusions        | empty list                     | CLI                   | List of prefixes which should not be processed in imports            |  `lein source-deps :prefix-exclusions "[\"classlojure\"]"`  |
+| project-prefix           | mranderson{rnd}                | CLI                   | project pecific prefix to use when shadowing            | `lein inline-deps :project-prefix cider.inlined-deps` |
+| skip-javaclass-repackage | false                          | CLI                   | If true [Jar Jar Links](https://code.google.com/p/jarjar/) won't be used to repackage java classes in dependencies            | `lein inline-deps :skip-javaclass-repackage true`        |
+| prefix-exclusions        | empty list                     | CLI                   | List of prefixes which should not be processed in imports            |  `lein inline-deps :prefix-exclusions "[\"classlojure\"]"`  |
 | watermark                | :mranderson/inlined            | project.clj           | When processing namespaces in dependencies MrAnderson marks them with a meta so inlined namespaces can be identified. Helpful for tools like [cljdoc](https://cljdoc.org)            | `:mranderson {:watermark nil}` to switch off watermarking or provide your own keyword        |
-| unresolved-tree          | false                          | CLI, project.clj      | Switch between **unresolved tree** and **resolved tree** mode | `lein source-deps :unresolved-tree true` |
+| unresolved-tree          | false                          | CLI, project.clj      | Switch between **unresolved tree** and **resolved tree** mode | `lein inline-deps :unresolved-tree true` |
 | overrides                | empty list                     | project.clj           | Defines dependency overrides in **unresolved tree** mode | `:mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}` |
 | expositions              | empty list                     | project.clj           | Makes transient dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Alternatively the modified dependencies and project files can be copied back to 
 
 ## Config and options
 
-### Two modes: unresolved dependency tree and shadowing only
+### Two modes: shadowing only and deeply nested
 
-MrAnderson has **two modes**. It can either work on an unresolved dependency tree (the default) or only shadow a list of dependencies based on a resolved dependency tree.
+MrAnderson has **two modes**. It can either created a **deeply nested** directory structure for the unresolved dependency tree based on the marked dependencies or only shadow (**shadow only** -- the default) a list of dependencies based on a resolved dependency tree of the same dependencies.
 
-Working on an **unresolved dependency tree** means that the same library -- even the same version of the library -- can occur multiple times in the dependency tree. When processing the tree MrAnderson walks it in a depth first order and creates a deeply nested directory structure and prefixes the namespaces and the references to them according to this directory structure.
+In **deeply nested** mode the same library -- even the same version of the library -- can occur multiple times in the unresolved dependency tree. When processing the tree MrAnderson walks it in a depth first order and creates a deeply nested directory structure and prefixes the namespaces and the references to them according to this directory structure.
 
 Let's see [cider-nrepl](https://github.com/clojure-emacs/cider-nrepl)'s list of dependencies in the project file (as it is at the time of writing this README):
 
@@ -151,7 +151,7 @@ and a reference to it in `cider.inlined-deps.rewrite-clj.v0v6v0.rewrite-clj.read
              [edn :as edn])
 ```
 
-In the **unresolved dependency tree** mode the usual way of overriding dependencies, eg. putting a first level dependency in the project file with a newer version of a library does not work. Also in this mode MrAnderson applies transient dependency hygiene meaning that it does not search and replace occurrances of a transient depedency namespace in the project's own files. To work around these limitations you can create a MrAnderson specific section in the project file and define overrides as such:
+In the **deeply nested** mode the usual way of overriding dependencies, eg. putting a first level dependency in the project file with a newer version of a library does not work. Also in this mode MrAnderson applies transient dependency hygiene meaning that it does not search and replace occurrances of a transient depedency namespace in the project's own files. To work around these limitations you can create a MrAnderson specific section in the project file and define overrides as such:
 
 ```clojure
 :mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}
@@ -167,15 +167,15 @@ In the same section you can instruct MrAnderson to expose certain transient depe
 
 Here you have to provide a list of paths to dependencies to be exposed.
 
-To use the **shadowing only** mode you can either provide a flag in the above mentioned section
+To use the **deeply nested** mode you can either provide a flag in the above mentioned section
 
 ```clojure
-:mranderson {:shadowing-only true}
+:mranderson {:deeply-nested true}
 ```
 
 or you can provide the same flag on the command line:
 
-    $ lein source-deps :shadowing-only true
+    $ lein source-deps :deeply-nested true
 
 The latter supersedes the former.
 
@@ -189,9 +189,9 @@ Again: in the **shadowing only** mode no transient dependency hygiene is applied
 | skip-javaclass-repackage | false                          | CLI                   | If true [Jar Jar Links](https://code.google.com/p/jarjar/) won't be used to repackage java classes in dependencies            | `lein source-deps :skip-javaclass-repackage true`        |
 | prefix-exclusions        | empty list                     | CLI                   | List of prefixes which should not be processed in imports            |  `lein source-deps :prefix-exclusions "[\"classlojure\"]"`  |
 | watermark                | :mranderson/inlined            | project.clj           | When processing namespaces in dependencies MrAnderson marks them with a meta so inlined namespaces can be identified. Helpful for tools like [cljdoc](https://cljdoc.org)            | `:mranderson {:watermark nil}` to switch off watermarking or provide your own keyword        |
-| shadowing-only           | false                          | CLI, project.clj      | Switch between **unresolved tree** and **shadowing only** mode | `lein source-deps :shadowing-only true` |
-| overrides                | empty list                     | project.clj           | Defines dependency overrides in **unresolved tree** mode | `:mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}` |
-| expositions              | empty list                     | project.clj           | Makes transient dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
+| deeply-nested           | false                          | CLI, project.clj      | Switch between **deeply nested** and **shadowing only** mode | `lein source-deps :deeply-nested true` |
+| overrides                | empty list                     | project.clj           | Defines dependency overrides in **deeply nested** mode | `:mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}` |
+| expositions              | empty list                     | project.clj           | Makes transient dependencies available in the project's source files in **deeply nested** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
 
 ## Prerequisites
 
@@ -201,7 +201,7 @@ Leiningen 2.8.3 or above. For MrAnderson to work, does not mean your project is 
 
 Yes and yes.
 
-Use it if you have dependency conflicts and don't care to solve them. In unresolved tree mode MrAnderson creates deeply nested, local dependencies where any subtree is isolated from the rest of the tree therefore the same library can occur several times without conflicting. Or use it if you don't want your library's dependencies to interfere with the dependencies of your users' (leiningen plugins is a good example here). Or if you want to explore a bit more in the hellish land of dependency handling.
+Use it if you have dependency conflicts and don't care to solve them. In **deeply nested** mode MrAnderson creates deeply nested, local dependencies where any subtree is isolated from the rest of the tree therefore the same library can occur several times without conflicting. Or use it if you don't want your library's dependencies to interfere with the dependencies of your users' (leiningen plugins is a good example here). Or if you want to explore a bit more in the hellish land of dependency handling.
 
 ### Projects that use MrAnderson
 

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -1,4 +1,4 @@
-(ns leiningen.source-deps
+(ns leiningen.inline-deps
   (:require [clojure.edn :as edn]
             [me.raynes.fs :as fs]
             [mranderson.core :as c]
@@ -24,8 +24,8 @@
         prefix-exclusions           (lookup-opt :prefix-exclusions opts)
         srcdeps-relative            (str (apply str (drop (inc (count root)) target-path)) "/srcdeps")
         project-source-dirs         (filter fs/directory? (.listFiles (fs/file (str target-path "/srcdeps/"))))
-        deeply-nested-opt           (lookup-opt :deeply-nested opts)
-        deeply-nested               (or deeply-nested-opt (and (nil? deeply-nested-opt) (:deeply-nested mranderson)))]
+        unresolved-tree-opt         (lookup-opt :unresolved-tree opts)
+        unresolved-tree             (or unresolved-tree-opt (and (nil? unresolved-tree-opt) (:unresolved-tree mranderson)))]
     (u/debug "skip repackage" skip-repackage-java-classes)
     (u/debug "project mranderson" (prn-str mranderson))
     (u/info "project prefix: " project-prefix)
@@ -36,7 +36,7 @@
      :srcdeps                     srcdeps-relative
      :prefix-exclusions           prefix-exclusions
      :project-source-dirs         project-source-dirs
-     :deeply-nested               deeply-nested
+     :unresolved-tree             unresolved-tree
      :overrides                   (:overrides mranderson)
      :expositions                 (:expositions mranderson)
      :watermark                   (:watermark mranderson :mranderson/inlined)}))
@@ -46,10 +46,15 @@
    :parent-clj-dirs []
    :branch          []})
 
-(defn source-deps
-  "Dependencies as source: used as if part of the project itself.
+(defn inline-deps
+  "Inline and shadow dependencies so they can not interfere with other libraries' dependencies.
 
-   Somewhat node.js & npm style dependency handling."
+  Available options:
+
+  :project-prefix           string    Project prefix to use when shadowing
+  :skip-javaclass-repackage boolean   If true Jar Jar Links won't be used to repackage java classes
+  :prefix-exclusions        list      List of prefixes that should not be processed in imports
+  :unresolved-tree          boolean   Enforces unresolved tree mode"
   [{:keys [repositories dependencies source-paths target-path] :as project} & args]
   (c/copy-source-files source-paths target-path)
   (let [{:keys [pprefix] :as ctx} (lein-project->ctx project args)

--- a/src/leiningen/source_deps.clj
+++ b/src/leiningen/source_deps.clj
@@ -24,8 +24,8 @@
         prefix-exclusions           (lookup-opt :prefix-exclusions opts)
         srcdeps-relative            (str (apply str (drop (inc (count root)) target-path)) "/srcdeps")
         project-source-dirs         (filter fs/directory? (.listFiles (fs/file (str target-path "/srcdeps/"))))
-        shadowing-only-opt          (lookup-opt :shadowing-only opts)
-        shadowing-only              (or shadowing-only-opt (and (nil? shadowing-only-opt) (:shadowing-only mranderson)))]
+        deeply-nested-opt           (lookup-opt :deeply-nested opts)
+        deeply-nested               (or deeply-nested-opt (and (nil? deeply-nested-opt) (:deeply-nested mranderson)))]
     (u/debug "skip repackage" skip-repackage-java-classes)
     (u/debug "project mranderson" (prn-str mranderson))
     (u/info "project prefix: " project-prefix)
@@ -36,7 +36,7 @@
      :srcdeps                     srcdeps-relative
      :prefix-exclusions           prefix-exclusions
      :project-source-dirs         project-source-dirs
-     :shadowing-only              shadowing-only
+     :deeply-nested               deeply-nested
      :overrides                   (:overrides mranderson)
      :expositions                 (:expositions mranderson)
      :watermark                   (:watermark mranderson :mranderson/inlined)}))

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -262,7 +262,7 @@
   "Unzips and transforms files in an unresolved dependency tree."
   [unresolved-deps-tree paths ctx]
   (let [unresolved-deps-tree (t/evict-subtrees unresolved-deps-tree '#{org.clojure/clojure org.clojure/clojurescript})]
-    (u/info "working on an unresolved dependency hierarchy")
+    (u/info "in DEEPLY-NESTED mode, working on an unresolved dependency tree")
     (t/walk-deps unresolved-deps-tree print-dep)
     (t/walk-dep-tree unresolved-deps-tree unzip-artifact! update-artifact! paths ctx)))
 
@@ -283,7 +283,7 @@
                                         (filter vector?)
                                         (reduce (fn [m dep] (assoc m dep nil)) {})
                                         (into (sorted-map-by topo-comparator)))]
-    (u/info "working on a resolved dep hierarchy")
+    (u/info "in SHADOWING-ONLY mode, working on a resolved dependency tree")
     (t/walk-deps resolved-deps print-dep)
     (t/walk-ordered-deps
      ordered-resolved-deps
@@ -293,15 +293,15 @@
      ctx)))
 
 (defn mranderson
-  [repositories dependencies {:keys [skip-repackage-java-classes shadowing-only pname pversion overrides] :as ctx} paths]
+  [repositories dependencies {:keys [skip-repackage-java-classes deeply-nested pname pversion overrides] :as ctx} paths]
   (let [source-dependencies         (filter u/source-dep? dependencies)
         resolved-deps-tree          (dr/resolve-source-deps repositories source-dependencies)
-        overrides                   (or (and shadowing-only {}) overrides)
+        overrides                   (or (and deeply-nested overrides) {})
         unresolved-deps-tree        (dr/expand-dep-hierarchy repositories resolved-deps-tree overrides)]
     (u/info "retrieve dependencies and munge clojure source files")
-    (if shadowing-only
-      (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx)
-      (mranderson-unresolved-deps! unresolved-deps-tree paths ctx))
+    (if deeply-nested
+      (mranderson-unresolved-deps! unresolved-deps-tree paths ctx)
+      (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))
     (when-not (or skip-repackage-java-classes (empty? (u/class-files)))
       (class-deps-jar!)
       (u/apply-jarjar! pname pversion)


### PR DESCRIPTION
- Rename `source-deps` -> `inline-deps`
- Rename two available modes to `unresolved tree` and `resolved tree` (latter is default)
- modify README accordingly
- further README tweaks