### PR TITLE
Fix #44: Duplicated namespaces (e.g. in riddley)

### DIFF
--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -213,7 +213,7 @@
                               (mapv fs/file))]
     (u/info (format "  munge source files of %s artifact on branch %s exposed %s." art-name-cleaned branch (boolean expose?)))
     (u/debug "    proj-source-dirs" project-source-dirs " clj files" clj-files "clj dirs" clj-dirs " path to dep" src-path "parent-clj-dirs: " parent-clj-dirs)
-    (u/debug "   modified namespace prefix: " repl-prefix)
+    (u/debug "    modified namespace prefix: " repl-prefix)
     (u/debug "    src path: " src-path)
     (u/debug "    parent clj dirs: " (str/join ":" parent-clj-dirs))
     (u/debug "    all dirs: " all-deps-dirs)

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -232,9 +232,9 @@
             (move/replace-ns-symbol-in-source-files old-ns new-ns (u/file->extension (str clj-file)) project-source-dirs nil)))
         ;; a clj file without ns
         (when-not (= "project.clj" clj-file)
-          (let [old-path (str "target/srcdeps/" clj-file)
+          (let [old-path (fs/file srcdeps clj-file)
                 new-path (str (u/sym->file-name pprefix) "/" art-name-cleaned "/" art-version "/" clj-file)]
-            (fs/copy+ old-path (str "target/srcdeps/" new-path))
+            (fs/copy+ old-path (fs/file srcdeps new-path))
             ;; replace occurrences of file path references
             (doseq [file (u/clojure-source-files [srcdeps])]
               (update-path-in-file file clj-file new-path))

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -242,7 +242,7 @@
   returns modified source as a string.
 
   Splits the source file, parses the ns macro if found to do all the necessary
-  transformations. Works on the body of namepsace as text as simpler transformations
+  transformations. Works on the body of namespace as text as simpler transformations
   are needed. When done puts the ns form and body back together."
   [content old-sym new-sym watermark extension-of-moved file-ext]
   (let [[ns-loc source-sans-ns] (split-ns-form-ns-body content)

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -247,7 +247,8 @@
   [content old-sym new-sym watermark extension-of-moved file-ext]
   (let [[ns-loc source-sans-ns] (split-ns-form-ns-body content)
         opposite-platform       (util/platform-comp (util/extension->platform extension-of-moved))
-        [replaced-nodes ns-loc] (or (and (= ".cljc" file-ext)
+        [replaced-nodes ns-loc] (or (and ns-loc
+                                         (= ".cljc" file-ext)
                                          opposite-platform
                                          (find-and-replace-platform-specific-subforms opposite-platform ns-loc))
                                     [[] ns-loc])

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -1,0 +1,67 @@
+(ns mranderson.core-test
+  (:require [mranderson.test :refer [with-mranderson]]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :refer :all]))
+
+;; ## Fixtures
+
+(def dependencies
+  '[^:inline-dep [org.clojure/data.xml "0.2.0-alpha6"]
+    ^:inline-dep [riddley "0.1.12"]
+    ^:inline-dep [cljfmt "0.7.0"]])
+
+(def clojure-namespace-file
+  {:path   "mrt/main.clj"
+   :content (str "(ns mrt.main\n"
+                 "  (:require [riddley.walk :as rw]"
+                 "            [clojure.data.xml :as xml]))")})
+
+(def clojure-resource-file
+  {:path   "mrt/resource.clj"
+   :content (pr-str [{:position {:x 1, :y 1}, :color :red}])})
+
+;; ## Helpers
+
+(defn- ->file
+  [{:keys [working-directory]} {:keys [path]}]
+  (io/file working-directory path))
+
+;; ## Tests
+
+(deftest t-resolved-tree-and-skip-java-repackage-classes
+  (with-mranderson
+    [project {:dependencies dependencies
+              :files        [clojure-namespace-file
+                             clojure-resource-file]
+              :opts         {:skip-repackage-java-classes true
+                             :unresolved-tree             false}}]
+    (let [{:keys [working-directory prefix ns-prefix]} project]
+
+      (testing "Clojure source file was correctly updated"
+        (let [riddley-prefix (str ns-prefix ".riddley.v0v1v12.riddley")
+              xml-prefix     (str ns-prefix ".dataxml.v0v2v0-alpha6.clojure.data.xml")
+              main-file      (->file project clojure-namespace-file)]
+          (is (= (-> (:content clojure-namespace-file)
+                     (string/replace "riddley" riddley-prefix)
+                     (string/replace "clojure.data.xml" xml-prefix))
+                 (slurp main-file)))))
+
+      (testing "Clojure resource file was not changed"
+        (let [resource-file (->file project clojure-resource-file)]
+          (is (= (:content clojure-resource-file)
+                 (slurp resource-file)))))
+
+      (testing "Dependency source file was correctly updated"
+        (let [riddley-file (io/file working-directory
+                                    prefix
+                                    "riddley"
+                                    "v0v1v12"
+                                    "riddley"
+                                    "walk.clj")]
+          (is (string/starts-with?
+                (slurp riddley-file)
+                (str "(ns ^{:mranderson/inlined true} " ns-prefix ".riddley.v0v1v12.riddley.walk\n"
+                     "  (:refer-clojure :exclude [macroexpand])\n"
+                     "  (:require\n"
+                     "    [" ns-prefix ".riddley.v0v1v12.riddley.compiler :as cmp]))"))))))))

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -99,6 +99,10 @@
 
 (def ex-seven-cljs "(ns example.seven)")
 
+(def ex-data-readers
+  "{xml/ns clojure.data.xml.name/uri-symbol
+ xml/element clojure.data.xml.node/tagged-element}")
+
 (def medley-user-example
   "(ns example.user.medley
  (:require [medley.core :as medley]))")
@@ -159,6 +163,7 @@
         file-cljc     (create-source-file! (io/file example-dir "cross.cljc") ex-cljc)
         file-seven-clj  (create-source-file! (io/file example-dir "seven.clj") ex-seven-clj)
         file-seven-cljs (create-source-file! (io/file example-dir "seven.cljs") ex-seven-cljs)
+        file-data-readers (create-source-file! (io/file example-dir "data_readers.cljc") ex-data-readers)
         medley-dir   (io/file src-dir "medley")
         file-medley  (create-source-file! (io/file medley-dir "core.clj") medley-stub)
         file-medley-user (create-source-file! (io/file example-dir "user" "medley.clj") medley-user-example)
@@ -202,6 +207,8 @@
               "type of occurence is retained if keyword")
         (t/is (re-find #"\[example\.b\s*\[foo\]\s*\[bar\]\]" (slurp file-two))
               "prefixes should be replaced")
+        (t/is (= ex-data-readers (slurp file-data-readers))
+              "cljc file w/o ns macro is unchanged")
         (t/is (= ex-edn (slurp file-edn))
               "clj file wo/ ns macro is unchanged"))
 

--- a/test/mranderson/test.clj
+++ b/test/mranderson/test.clj
@@ -1,0 +1,98 @@
+(ns mranderson.test
+  (:require [mranderson.core :refer [mranderson]]
+            [me.raynes.fs :as fs]
+            [clojure.java.io :as io]
+            [clojure.test :as t])
+  (:import (java.io File)))
+
+;; ## Fixtures
+
+(def ^:private repositories
+  [["central" {:url "https://repo1.maven.org/maven2/", :snapshots false}]
+   ["clojars" {:url "https://repo.clojars.org/"}]])
+
+;; ## Helpers
+
+(defmacro ^:private with-temp-dir
+  "Create a temporary directory, run the body, then clean up the directory."
+  [sym & body]
+  `(let [f# (doto (File/createTempFile "mranderson" "")
+              (.delete)
+              (.mkdirs))
+         ~sym f#]
+     (try
+       (do ~@body)
+       (finally
+         (fs/delete-dir f#)))))
+
+(defn ^:private create-files!
+  "Create files and return root directories that contain them."
+  [working-directory files]
+  (->> (for [{:keys [path content]} files]
+         (let [dirname     (first (.split ^String path "/"))
+               target-file (io/file working-directory path)]
+           (.. target-file (getParentFile) (mkdirs))
+           (spit target-file  content)
+           (io/file working-directory dirname)))
+       (distinct)
+       (doall)))
+
+(defmacro ^:private with-project
+  "Set up a temporary directory with a structure that can be used by
+   mranderson."
+  [[sym files] & body]
+  `(with-temp-dir tmp#
+     (let [working-directory#  (doto (io/file tmp# "srcdeps")
+                                (.mkdirs))
+           source-directories# (create-files! working-directory# ~files)
+           prefix#             (str "mranderson_test" (rand-int 99999))
+           ~sym                {:prefix             prefix#
+                                :ns-prefix          (.replace prefix# "_" "-")
+                                :working-directory  working-directory#
+                                :source-directories source-directories#}]
+       ~@body)))
+
+(defn- project->context
+  "Convert the given project map into a context map for mranderson."
+  [{:keys [^File working-directory
+           source-directories
+           prefix]}
+   & [opts]]
+  (merge
+    {:pprefix                     prefix
+     :pname                       "mranderson-test"
+     :pversion                    "0.1.0-SNAPSHOT"
+
+     :project-source-dirs         source-directories
+     :srcdeps                     (.getPath working-directory)
+
+     :skip-repackage-java-classes false
+     :unresolved-tree             false
+
+     :watermark                   :mranderson/inlined
+     :expositions                 nil
+     :overrides                   nil
+     :prefix-exclusions           nil}
+    opts))
+
+(defn- project->paths
+  [{:keys [^File working-directory prefix]}]
+  "Convert the given project map into a paths map for mranderson."
+  {:src-path        (io/file working-directory prefix)
+   :parent-clj-dirs []
+   :branch          []})
+
+;; ## Run
+
+(defn with-mranderson*
+  [{:keys [dependencies files opts]} f]
+  (with-project [project files]
+    (mranderson repositories
+                dependencies
+                (project->context project opts)
+                (project->paths project))
+    (f project)))
+
+(defmacro with-mranderson
+  [[project {:keys [dependencies files opts] :as spec}] & body]
+  `(with-mranderson* ~spec (fn [~project] ~@body)))


### PR DESCRIPTION
This is my attempt at fixing #44, which I ran into when trying to use mranderson with lein-ancient. To preserve backwards-compatibility as far as possible, I elected to only act if there was more than one file in a package that resolves to the same namespace. Additional consideration was necessary to not accidentally remove files if there were both CLJ/CLJS sources in the package.

All in all, the effect might be very similar to that of ba9154cc315533c0170dc44a36c344d4155593f6, just makes the logic a bit more explicit and moves it to a higher level instead of having it deep inside `update-artifact!`.

This PR also includes a fix for replacing namespace symbols in a `data_readers.cljc`. Currently, mranderson chokes on [this file](https://github.com/clojure/data.xml/blob/master/src/main/clojure/data_readers.cljc) because it expects all CLJC files to have a namespace declaration. I think we should be more forgiving here.

