### PR TITLE
Migrate jarjar:1.3 to org.pantsbuild.jarjar:1.7.2

### DIFF
--- a/java-src/mranderson/util/JjMainProcessor.java
+++ b/java-src/mranderson/util/JjMainProcessor.java
@@ -20,8 +20,10 @@
 
 package mranderson.util;
 
-import com.tonicsystems.jarjar.*;
-import com.tonicsystems.jarjar.ext_util.*;
+import org.pantsbuild.jarjar.PatternElement;
+import org.pantsbuild.jarjar.Rule;
+import org.pantsbuild.jarjar.util.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.*;

--- a/java-src/mranderson/util/JjPackageRemapper.java
+++ b/java-src/mranderson/util/JjPackageRemapper.java
@@ -20,10 +20,14 @@
 
 package mranderson.util;
 
-import com.tonicsystems.jarjar.*;
-import com.tonicsystems.jarjar.asm.*;
-import com.tonicsystems.jarjar.asm.commons.*;
-import java.util.*;
+import org.objectweb.asm.commons.Remapper;
+import org.pantsbuild.jarjar.PatternElement;
+import org.pantsbuild.jarjar.Rule;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class JjPackageRemapper extends Remapper

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  ^:inline-dep [me.raynes/fs "1.4.6"]
                  ^:inline-dep [rewrite-clj "0.6.1"]
                  ^:inline-dep [parallel "0.10"]
-                 [com.googlecode.jarjar/jarjar "1.3"]]
+                 [org.pantsbuild/jarjar "1.7.2"]]
   :mranderson {:project-prefix "mranderson.inlined"}
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [leiningen-core "2.9.1"]]}

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -4,9 +4,9 @@
             [leiningen.core.main :as lein-main]
             [clojure.set :as s])
   (:import [java.io File]
-           [com.tonicsystems.jarjar Rule]
+           [org.pantsbuild.jarjar Rule]
            [mranderson.util JjPackageRemapper JjMainProcessor]
-           [com.tonicsystems.jarjar.ext_util StandaloneJarProcessor]))
+           [org.pantsbuild.jarjar.util StandaloneJarProcessor]))
 
 (defn info [& args]
   (apply lein-main/info args))


### PR DESCRIPTION
More speculative than anything, but thought I'd try migrating to use https://github.com/pantsbuild/jarjar rather than the old googlecode one. This one's also archived/read-only, but seems like it at least resolves #48. I did also consider the https://github.com/shevek/jarjar fork but this doesn't seem to have been released to Maven in a while...