### PR TITLE
remove-subdirs handles subdirs where one dir-name is a prefix of another

### DIFF
--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -156,9 +156,11 @@
   (->> (sort dirs)
        (reduce (fn [ds dir]
                  (let [last-dir (last ds)]
-                   (if (and last-dir (str/includes? dir last-dir))
+                   (if (and last-dir (str/includes? (str dir File/separator)
+                                                    (str last-dir File/separator)))
                      ds
-                     (conj ds dir)))) [])))
+                     (conj ds dir))))
+               [])))
 
 (defn clj-files->dirs
   [prefix clj-files]

--- a/test/mranderson/util_test.clj
+++ b/test/mranderson/util_test.clj
@@ -1,0 +1,9 @@
+(ns mranderson.util-test
+  (:require [mranderson.util :as util]
+            [clojure.test :as t]))
+
+(t/deftest test-removes-subdirs
+  (t/testing "handles subdirs where one dir-name is a prefix of another"
+    (t/are [expected dirs] (t/is (= expected (util/remove-subdirs dirs)))
+      ["hiccup"] ["hiccup/foo" "hiccup"]
+      ["hiccup" "hiccup2"] ["hiccup/foo" "hiccup" "hiccup2"])))


### PR DESCRIPTION
Hey there :smile: 

Fixing a bug in `remove-subdirs` where it was excluding directories where one name was a prefix of another. e.g. in `[hiccup "2.0.0-alpha2"]` it has `hiccup.*` and `hiccup2.*` - the latter weren't getting included because `target/srcdeps/hiccup` is a sub-string of `target/srcdeps/hiccup2`, but one isn't a sub-dir of the other.

There are likely safer methods to do this in [Path](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html) that don't involve string munging - guessing we can't use these due to Java version requirements or something?

Cheers,

James