### PR TITLE
Bump MrAnderson deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+
 ## Bug fixes
 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name
@@ -9,6 +10,7 @@
 
 ## Changes
 
+- [maint [#66](https://github.com/benedekfazekas/mranderson/issues/66)] bump MrAnderson dependencies
 - [fix [#63](https://github.com/benedekfazekas/mranderson/pull/63)] introduce `mranderson.internal.no-parallelism` as on option temporarily
 - integration tests against `cider-nrepl` and `refactor-nrepl`
 - improve CI matrix

--- a/project.clj
+++ b/project.clj
@@ -12,18 +12,19 @@
                     ;; https://saker.build/blog/javac_source_target_parameters/index.html / https://archive.md/JH260
                     ["--release" "8"])
   :filespecs [{:type :bytes :path "mranderson/project.clj" :bytes ~(slurp "project.clj")}]
-  :dependencies [^:inline-dep [com.cemerick/pomegranate "0.4.0"]
-                 ^:inline-dep [org.clojure/tools.namespace "1.1.0"]
-                 ^:inline-dep [me.raynes/fs "1.4.6"]
-                 ^:inline-dep [rewrite-clj "1.0.682-alpha"]
+  :dependencies [^:inline-dep [clj-commons/pomegranate "1.2.1"]
+                 ^:inline-dep [org.clojure/tools.namespace "1.3.0"]
+                 ^:inline-dep [clj-commons/fs "1.6.310"]
+                 ^:inline-dep [rewrite-clj "1.1.45"]
                  [org.clojure/clojure "1.10.3" :scope "provided"]
                  [org.pantsbuild/jarjar "1.7.2"]]
   :mranderson {:project-prefix "mranderson.inlined"}
-  :profiles {:dev {:dependencies [[leiningen-core "2.9.1"]]}
-             :eastwood {:plugins      [[jonase/eastwood "0.9.9"]]
-                        :eastwood     {:exclude-linters [:no-ns-form-found]}}
+  :profiles {:dev {:dependencies [[leiningen-core "2.9.10"]]}
+             :eastwood {:plugins [[jonase/eastwood "1.3.0"]]
+                        :eastwood {:exclude-linters [:no-ns-form-found]}}
              :mranderson-plugin {:plugins [[thomasa/mranderson ~project-version]]}
              ;; copy of plugin.mranderson/config profile, needed here so mrandersoned pom/jar can be built for mranderson itself
+             ;; see Makefile for usage
              :mranderson-profile ^:leaky {:omit-source true
                                           :source-paths ["target/srcdeps"]
                                           :filespecs [{:type :paths :paths ["target/srcdeps"]}]
@@ -31,8 +32,9 @@
                                           :srcdeps-project-hacks true
                                           :middleware [mranderson.plugin/middleware]
                                           :jar-exclusions [#"(?i)^META-INF/.*"]}
-             :kaocha {:dependencies [[lambdaisland/kaocha "0.0-418"]
-                                     [lambdaisland/kaocha-cloverage "0.0-32"]]}}
+             :kaocha {:eval-in :sub-process
+                      :dependencies [[lambdaisland/kaocha "1.69.1069"]
+                                     [lambdaisland/kaocha-cloverage "1.0.75"]]}}
   :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]
             "kaocha-watch" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--watch"]
             "kaocha-coverage" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--plugin" "cloverage"]})

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,2 @@
+#kaocha/v1
+{:reporter kaocha.report/documentation}


### PR DESCRIPTION
Two projects moved to clj-commons:
- me.raynes/fs -> clj-commons/fs
- com.cemerick/pomegranate -> clj-commons/pomegranate

Eastwood noticed that rewrite-clj has deprecated
`rewrite-clj.zip/edn`. This is a name change only to `rewrite-clj.zip/of-node`.

Left Clojure version as is at 1.10.3 because it implies the minimum Clojure version that MrAnderson supports.

The koacha cloverage plugin now checks for data readers on the classpath. When running `:eval-in :leiningen`, this check fails with a null pointer exception. Now doing an `:eval-in :sub-process` for koacha profile.

Also added a `tests.edn` for koacha because it really wanted me to.

Closes #66