### PR TITLE
dev: tweak git ignores

### DIFF
--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 *~
+/.clj-kondo/.cache
+/.lsp
+/.inline
+/.eastwood


### PR DESCRIPTION
Of note:
- Many people now use clj-kondo, exclude its cache, but include exported clj-kondo configs from libraries we use.
- Lots of people also use clojure-lsp now. Exclude the .lsp dir.