### PR TITLE
dev: include basic clj-kondo config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,7 @@
+{:config-paths ^:replace [] ;; don't pick up user defaults
+ :lint-as
+ {mranderson.test/with-mranderson clojure.core/let
+  mranderson.test/with-project clojure.core/let}
+ :linters
+ {:unused-binding {:exclude-destructured-keys-in-fn-args true}
+  :cond-else {:level :off}}}

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -6,7 +6,7 @@
             [clojure.set :as s])
   (:import [java.io File]
            [org.pantsbuild.jarjar Rule]
-           [mranderson.util JjPackageRemapper JjMainProcessor]
+           [mranderson.util JjMainProcessor]
            [org.pantsbuild.jarjar.util StandaloneJarProcessor]))
 
 (defn info [& args]


### PR DESCRIPTION
Like eastwood, clj-kondo can help to find mistakes, but it can do so while you edit source. A very tight feedback loop!

This PR adds a basic clj-kondo config. It tells clj-kondo:
- to interpret MrAnderson test macros like Clojure's `let`
- that it is ok that MrAnderson code cond default is not `:else` (MrAnderson uses `:default`)
- to not warn on unused destructured keys

Also:
- clj-kondo found an unused import. Turfed it.