### PR TITLE
Don't rewrite CLJ/CLJC files twice

### DIFF
--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -220,7 +220,7 @@
         (doall
          (map #(prefix-dependency-imports! pname pversion pprefix % (str src-path) srcdeps) prefixes))
         (prefix-dependency-imports! pname pversion pprefix nil (str src-path) srcdeps)))
-    (doseq [clj-file clj-files
+    (doseq [clj-file (sort-by str clj-files)
             :let [extension (u/file->extension (str clj-file))]]
       (if-let [old-ns (->> clj-file (fs/file srcdeps) read-file-ns-decl second)]
         (let [new-ns (if (str/starts-with? old-ns repl-prefix)

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -11,6 +11,7 @@
 
 (def dependencies
   '[^:inline-dep [org.clojure/data.xml "0.2.0-alpha6"]
+    ^:inline-dep [instaparse "1.4.12"]
     ^:inline-dep [riddley "0.1.12"]
     ^:inline-dep [cljfmt "0.7.0"]])
 
@@ -40,7 +41,6 @@
               :opts         {:skip-repackage-java-classes true
                              :unresolved-tree             false}}]
     (let [{:keys [working-directory prefix ns-prefix]} project]
-
       (testing "Clojure source file was correctly updated"
         (let [riddley-prefix (str ns-prefix ".riddley.v0v1v12.riddley")
               xml-prefix     (str ns-prefix ".dataxml.v0v2v0-alpha6.clojure.data.xml")
@@ -63,11 +63,19 @@
                                     "riddley"
                                     "walk.clj")]
           (is (string/starts-with?
-                (slurp riddley-file)
-                (str "(ns ^{:mranderson/inlined true} " ns-prefix ".riddley.v0v1v12.riddley.walk\n"
-                     "  (:refer-clojure :exclude [macroexpand])\n"
-                     "  (:require\n"
-                     "    [" ns-prefix ".riddley.v0v1v12.riddley.compiler :as cmp]))"))))))))
+               (slurp riddley-file)
+               (str "(ns ^{:mranderson/inlined true} " ns-prefix ".riddley.v0v1v12.riddley.walk\n"
+                    "  (:refer-clojure :exclude [macroexpand])\n"
+                    "  (:require\n"
+                    "    [" ns-prefix ".riddley.v0v1v12.riddley.compiler :as cmp]))")))))
+
+      (testing "Dependency source file"
+        (testing "with clj extension was correctly updated"
+          (let [content (slurp (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.clj"))]
+            (is (string/starts-with? content (str "(ns ^{:mranderson/inlined true} " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))
+        (testing "with cljc extension was correctly updated"
+          (let [content (slurp (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.cljc"))]
+           (is (string/starts-with? content (str "(ns ^{:mranderson/inlined true} " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))))))
 
 (deftest t-copy-source-files
   (testing "Can merge files across overlapping dirs"

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -71,11 +71,13 @@
 
       (testing "Dependency source file"
         (testing "with clj extension was correctly updated"
+          (println (first (line-seq (io/reader (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.clj")))))
           (let [content (slurp (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.clj"))]
             (is (string/starts-with? content (str "(ns ^{:mranderson/inlined true} " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))
         (testing "with cljc extension was correctly updated"
+          (println (first (line-seq (io/reader (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.cljc")))))
           (let [content (slurp (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.cljc"))]
-           (is (string/starts-with? content (str "(ns ^{:mranderson/inlined true} " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))))))
+            (is (string/starts-with? content (str "(ns ^{:mranderson/inlined true} " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))))))
 
 (deftest t-copy-source-files
   (testing "Can merge files across overlapping dirs"


### PR DESCRIPTION
Hello,

I would like to use Instaparse in Orchard and Cider as a dependency to
parse stacktraces formatted by Aviso, Clojure and Java, and show them
in the Cider stacktrace inspector.

In order to include Instaparse into the Cider middleware I think it
must be shipped as a inlined dependency produced via mranderson.

Unfortunatly, mranderson wasn't able to inline Instaparse. It replaced
namespace declarations in some of the files twice. The Instaparse JAR
looks like this:

```
drwxrwxrwx      0  21-Sep-2022 11:03:02  instaparse/
-rw-rw-rw-    461  21-Sep-2022 10:43:54  instaparse/viz.cljs
-rw-rw-rw-    579  21-Sep-2022 10:43:54  instaparse/util.cljc
-rw-rw-rw-    647  21-Sep-2022 11:03:02  instaparse/util.clj
-rw-rw-rw-    679  21-Sep-2022 10:43:54  instaparse/macros.clj
-rw-rw-rw-    954  21-Sep-2022 10:43:54  instaparse/combinators.cljc
-rw-rw-rw-   1029  21-Sep-2022 11:03:02  instaparse/combinators.clj
-rw-rw-rw-   1973  21-Sep-2022 10:43:54  instaparse/reduction.cljc
-rw-rw-rw-   2046  21-Sep-2022 11:03:02  instaparse/reduction.clj
-rw-rw-rw-   2795  21-Sep-2022 10:43:54  instaparse/transform.cljc
-rw-rw-rw-   2868  21-Sep-2022 11:03:02  instaparse/transform.clj
-rw-rw-rw-   2893  21-Sep-2022 10:43:54  instaparse/failure.cljc
-rw-rw-rw-   2964  21-Sep-2022 11:03:02  instaparse/failure.clj
-rw-rw-rw-   3560  21-Sep-2022 10:43:54  instaparse/print.cljc
-rw-rw-rw-   3629  21-Sep-2022 11:03:02  instaparse/print.clj
-rw-rw-rw-   4444  21-Sep-2022 10:43:54  instaparse/line_col.cljc
-rw-rw-rw-   4516  21-Sep-2022 11:03:02  instaparse/line_col.clj
-rw-rw-rw-   4563  21-Sep-2022 10:43:54  instaparse/viz.clj
-rw-rw-rw-   6631  21-Sep-2022 10:43:54  instaparse/combinators_source.cljc
-rw-rw-rw-   6713  21-Sep-2022 11:03:02  instaparse/combinators_source.clj
-rw-rw-rw-   9734  21-Sep-2022 10:43:54  instaparse/repeat.cljc
-rw-rw-rw-   9804  21-Sep-2022 11:03:02  instaparse/repeat.clj
-rw-rw-rw-  10112  21-Sep-2022 10:43:54  instaparse/abnf.cljc
-rw-rw-rw-  10180  21-Sep-2022 11:03:02  instaparse/abnf.clj
-rw-rw-rw-  12874  21-Sep-2022 11:02:54  instaparse/cfg.cljc
-rw-rw-rw-  12941  21-Sep-2022 11:03:02  instaparse/cfg.clj
-rw-rw-rw-  15492  21-Sep-2022 10:43:54  instaparse/core.cljc
-rw-rw-rw-  15560  21-Sep-2022 11:03:02  instaparse/core.clj
-rw-rw-rw-  15773  21-Sep-2022 10:43:54  instaparse/auto_flatten_seq.cljc
-rw-rw-rw-  15853  21-Sep-2022 11:03:02  instaparse/auto_flatten_seq.clj
-rw-rw-rw-  41596  21-Sep-2022 10:43:54  instaparse/gll.cljc
-rw-rw-rw-  41663  21-Sep-2022 11:03:02  instaparse/gll.clj
```

For some namepaces Instaparse has a CLJ and a CLJC file, the
`instaparse/line-col` namespace for example.

During the inlining done by mranderson, I observed the following
behaviour:

- Mr Anderson starts rewriting the instaparse dependency

- It has a list of files to rewrite, one after the other

- It starts rewriting `instaparse/line-col.clj`

- After rewriting `instaparse/line-col.clj` it rewrites all other
  files to refer to this new namespace, including
  `instaparse/line-col.cljc`

- When `instaparse/line-col.cljc` is picked up for rewriting it's
  namepace was alreday replaced, but mranderson rewites it again.

This PR avoids the double rewrite by checking if the file to be
processed has already the new namespace. If it does it is just moved
to the new location without rewriting it's content again.

What do you think of this fix?

[1] https://github.com/clojure-emacs/orchard/pull/164
