### PR TITLE
Fix intermitent broken files when inlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name
 - [fix [#49](https://github.com/benedekfazekas/mranderson/issues/49)] Options accepted from both CLI and the project map
 - [fix [#72](https://github.com/benedekfazekas/mranderson/issues/72)] Mranderson rewrites some clj/cljc files twice (instaparse)
+- [fix [#56](https://github.com/benedekfazekas/mranderson/issues/56)] Fix intermittent broken files when inlining
 
 ## Changes
 

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -206,7 +206,7 @@
                                parent-clj-dirs)
                               vec
                               (mapv str)
-                              u/remove-subdirs
+                              u/normalize-dirs
                               (mapv fs/file))]
     (u/info (format "  munge source files of %s artifact on branch %s exposed %s." art-name-cleaned branch (boolean expose?)))
     (u/debug "    proj-source-dirs" project-source-dirs " clj files" clj-files "clj dirs" clj-dirs " path to dep" src-path "parent-clj-dirs: " parent-clj-dirs)

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -293,8 +293,9 @@
   all Clojure source files found in dirs."
   [old-sym new-sym extension dirs watermark]
   (let [files (clojure-source-files dirs extension)
-        dupes (->> (map str files)
-                   frequencies
+        dupes (->> files
+                   (map str)
+                   (frequencies)
                    (filterv #(> (second %) 1)))]
     (if (seq dupes)
       (throw (ex-info "internal error: found unexpected duplicates in files" {:dupes dupes}))

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -153,14 +153,36 @@
        butlast
        (str/join "/")))
 
-(defn remove-subdirs [dirs]
-  (->> (sort dirs)
+(defn duplicated-files
+  "Returns map of duplicates in `files`, key is fully qualified file as string, value is num occurrences.
+  If no duplicates, empty map is returned."
+  [files]
+  (->> files
+       (map #(-> % str fs/normalized str))
+       (frequencies)
+       (filterv #(> (second %) 1))
+       (into {})))
+
+(defn assert-no-duplicate-files
+  "Throw internal error if there are any duplicates in `files`."
+  [files]
+  (let [dupes (duplicated-files files)]
+    (when (seq dupes)
+      (throw (ex-info "internal error: found unexpected duplicates in files" {:dupes dupes})))))
+
+(defn normalize-dirs
+  "Returns `dirs` (as strings) normalized, deduped and without subdirs"
+  [dirs]
+  (->> dirs
+       (map #(-> % str fs/normalized str))
+       sort
        distinct
        (reduce (fn [ds dir]
                  (let [last-dir (last ds)]
                    (if (and last-dir (fs/child-of? last-dir dir))
                      ds
-                     (conj ds dir)))) [])))
+                     (conj ds dir))))
+               [])))
 
 (defn clj-files->dirs
   [prefix clj-files]

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -27,13 +27,13 @@
             (mapcat file-seq)
             (remove (fn [file]
                       (some #(.startsWith (str file) %) excl-dirs) ))
-            (filter (fn [^File file]
-                      (let [file-name (.getName file)]
-                        (and (.isFile file)
-                             (or
-                              (.endsWith file-name ".cljc")
-                              (.endsWith file-name ".cljs")
-                              (.endsWith file-name ".clj")))))))))
+            (filterv (fn [^File file]
+                       (let [file-name (.getName file)]
+                         (and (.isFile file)
+                              (or
+                                (.endsWith file-name ".cljc")
+                                (.endsWith file-name ".cljs")
+                                (.endsWith file-name ".clj")))))))))
   ([dirs]
      (clojure-source-files-relative dirs nil)))
 
@@ -64,9 +64,9 @@
        (#(.listFiles ^File %))
        (filter #(.isDirectory ^File %))
        (mapcat file-seq)
-       (filter (fn [^File file]
-                 (and (.isFile file)
-                      (.endsWith (.getName file) ".class"))))))
+       (filterv (fn [^File file]
+                  (and (.isFile file)
+                       (.endsWith (.getName file) ".class"))))))
 
 (defn class-file->fully-qualified-name [file]
   (->> (-> file
@@ -155,6 +155,7 @@
 
 (defn remove-subdirs [dirs]
   (->> (sort dirs)
+       distinct
        (reduce (fn [ds dir]
                  (let [last-dir (last ds)]
                    (if (and last-dir (fs/child-of? last-dir dir))

--- a/test/mranderson/util_test.clj
+++ b/test/mranderson/util_test.clj
@@ -1,12 +1,43 @@
 (ns mranderson.util-test
   (:require [mranderson.util :as util]
+            [me.raynes.fs :as fs]
+            [clojure.java.io :as io]
             [clojure.test :as t]))
 
-(t/deftest test-removes-subdirs
-  (t/testing "handles subdirs where one dir-name is a prefix of another"
-    (t/are [expected dirs] (t/is (= expected (util/remove-subdirs dirs)))
-      ["hiccup"] ["hiccup/foo" "hiccup"]
-      ["hiccup" "hiccup2"] ["hiccup/foo" "hiccup" "hiccup2"])))
+(t/deftest duplicated-files-test
+  (t/is (= {}
+           (util/duplicated-files [(str (fs/file "a" "b" "c"))
+                                   (str (fs/file "a" "b" "d"))]))
+        "no duplicates")
+  (t/is (= {(str (fs/file "a" "b" "c")) 2}
+           (util/duplicated-files [(str (fs/file "a" "b" "c"))
+                                   (str (fs/file "a" "b" "c"))]))
+        "exact absolute duplicates")
+  (t/is (= {(str (fs/file "a" "b" "c")) 3}
+           (util/duplicated-files [(str (fs/file "a" "b" "c"))
+                                   (str (io/file "a" "b" "c"))
+                                   (str (io/file "a" "x" ".." "b" "c"))]))
+        "equivalent duplicates"))
+
+(t/deftest assert-no-duplicate-files-test
+  (t/is (nil? (util/assert-no-duplicate-files [(str (fs/file "a" "b" "c"))
+                                              (str (fs/file "a" "b" "d"))]))
+        "no throw on no dupes")
+  (t/is (= {:dupes {(str (fs/file "a" "b" "c")) 2}}
+           (try
+             (util/assert-no-duplicate-files [(str (fs/file "a" "b" "c"))
+                                             (str (fs/file "a" "b" "c"))])
+             (catch Throwable ex
+               (ex-data ex))))
+        "throw on dupes"))
+
+(t/deftest test-normalize-dirs
+  (t/testing "normalizes and removes subdirs where one dir-name is a prefix of another"
+    (t/are [expected dirs] (t/is (= (mapv #(-> % fs/file str) expected)
+                                    (util/normalize-dirs dirs)))
+      ["hiccup"]           ["hiccup/foo" "hiccup"]
+      ["hiccup" "hiccup2"] ["hiccup/foo" "hiccup" "hiccup2"]
+      ["hiccup" "hiccup2"] ["hiccup/foo/.." "hiccup/bar" (str (fs/file "hiccup/bingo")) "hiccup2/bar/.."])))
 
 (t/deftest determine-source-dirs
   (t/are [desc input expected] (t/testing desc
@@ -39,3 +70,4 @@
      :test-paths   ["test"]
      :mranderson   {:included-source-paths ["test" "foo"]}}
     ["test" "foo"]))
+


### PR DESCRIPTION
We had a wee bug which caused duplicate processing of the same source file for a single ns rename. Since we are, by default, processing files in parallel, this can lead to corrupt results.

This change:
- addresses the wee bug that caused duplicate processing: mranderson.util.remove-subdirs now also removes duplicate dirs.
- throws an internal error when duplicate files are detected prior to embarking on the ns rename processing

And also:
- any file-seq I noticed, I converted to non-lazy. These lazy file-seqs had me a bit confused during debugging, due to the way I was debugging, they were being resolved after files had changed on the filesystem.

Extra Testing

I did some extra testing using cider-nrepl v0.28.6 on macOS using Temurin 17.0.4.1 JDK. I ran 100 inline-dep generation runs against:
- current: 0.5.4-SNAPSHOT
- new: same but with this change

I compared target/srcdeps.

current:
- 13 of the 100 runs produced corrupt source files
- avg time to processs: 62.2s

new:
- 0 of 100 runs produced corrupt source files
- avg time to process: 53.8s

Closes #56