### PR TITLE
Replace lein logging with our own internal impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Changes
 
+- [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] uncouple MrAnderson from leiningen to support general use 
 - [maint [#66](https://github.com/benedekfazekas/mranderson/issues/66)] bump MrAnderson dependencies
 - [fix [#63](https://github.com/benedekfazekas/mranderson/pull/63)] introduce `mranderson.internal.no-parallelism` as on option temporarily
 - integration tests against `cider-nrepl` and `refactor-nrepl`

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -2,7 +2,8 @@
   (:require [clojure.edn :as edn]
             [me.raynes.fs :as fs]
             [mranderson.core :as c]
-            [mranderson.util :as u])
+            [mranderson.util :as u]
+            [mranderson.log :as log])
   (:import [java.util UUID]))
 
 (defn- lookup-opt
@@ -29,9 +30,9 @@
         prefix-exclusions           (lookup-opt :prefix-exclusions cli-opts mranderson)
         srcdeps-relative            (str (apply str (drop (inc (count root)) target-path)) "/srcdeps")
         project-source-dirs         (filter fs/directory? (.listFiles (fs/file (str target-path "/srcdeps/"))))]
-    (u/debug "skip repackage" skip-repackage-java-classes)
-    (u/debug "project mranderson" (prn-str mranderson))
-    (u/info "project prefix: " project-prefix)
+    (log/debug "skip repackage" skip-repackage-java-classes)
+    (log/debug "project mranderson" (prn-str mranderson))
+    (log/info "project prefix: " project-prefix)
     {:pname                       name
      :pversion                    version
      :pprefix                     project-prefix

--- a/src/mranderson/log.clj
+++ b/src/mranderson/log.clj
@@ -1,0 +1,36 @@
+(ns ^:no-doc mranderson.log
+  "Here we replicate lein logging.
+  This gives us what a lein plugin user would expect and is also reasonable for non-lein use.
+  We don't use's lein's logging methods because we don't want to tie ourselves to lein just for logging.
+  We also add in multi-threading support which lein logging does not do.")
+
+;; lein-isms for controlling logging
+(def ^:private log-info+? (not (System/getenv "LEIN_SILENT")))
+(def ^:private log-debug? (System/getenv "DEBUG"))
+
+;; a lock so (at least our) log line output do not get inter-mingled if we decide to log
+;; from multi-threaded work
+(def ^:private lock (Object.))
+
+(defn info
+  "Lein sends info to stdout, is silenced by LEIN_SILENT, so we do that too."
+  [& args]
+  (when log-info+?
+    (locking lock
+      (apply println args))))
+
+(defn warn
+  "Lein warns to stderr, is silenced by LEIN_SILENT, so we match that."
+  [& args]
+  (when log-info+?
+    (locking lock
+      (binding [*out* *err*]
+        (apply println args)))))
+
+(defn debug
+  "Lein's debug is enabled by DEBUG, sent to stdout, and is unaffected by LEIN_SILENT,
+  so we replicate that behaviour"
+  [& args]
+  (when log-debug?
+    (locking lock
+      (apply println args))))

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -2,21 +2,12 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
-            [leiningen.core.main :as lein-main]
-            [clojure.set :as s])
+            [clojure.set :as s]
+            [mranderson.log :as log])
   (:import [java.io File]
            [org.pantsbuild.jarjar Rule]
            [mranderson.util JjMainProcessor]
            [org.pantsbuild.jarjar.util StandaloneJarProcessor]))
-
-(defn info [& args]
-  (apply lein-main/info args))
-
-(defn warn [& args]
-  (apply lein-main/warn args))
-
-(defn debug [& args]
-  (apply lein-main/debug args))
 
 (defn clojure-source-files-relative
   ([dirs excl-dir]
@@ -114,7 +105,7 @@
         rules (map (partial create-rule name-version) java-dirs)
         processor (JjMainProcessor. rules false false)
         jar-file (io/file (str "target/class-deps.jar"))]
-    (info (format "prefixing %s in target/class-deps.jar with %s" java-dirs name-version))
+    (log/info (format "prefixing %s in target/class-deps.jar with %s" java-dirs name-version))
     (StandaloneJarProcessor/run jar-file jar-file processor)))
 
 (defn remove-2parents ^String [file]


### PR DESCRIPTION
We now replicate, instead of use, lein's logging.
And add in multi-threaded support.

This decouples us from lein for general use, and should allow API analysis on cljdoc to pass.

Closes #42