### PR TITLE
Fix watermarking moved namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 
+- [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name
 - [fix [#49](https://github.com/benedekfazekas/mranderson/issues/49)] Options accepted from both CLI and the project map
 - [fix [#72](https://github.com/benedekfazekas/mranderson/issues/72)] Mranderson rewrites some clj/cljc files twice (instaparse)


### PR DESCRIPTION
Optional watermark keyword metadata is now only added to renamed
namespace names.

Any existing metadata on renamed namespace name is now preserved.

Care was taken to preserve ordering and format of existing namespace
name metadata with the idea that it would make diffing inlined sources
against original sources more meaningful.

Fixed some existing test expectations.
Add some new tests to verify metadata handling.

Out of scope:
- I noticed that MrAnderson checks if it should rename ns name on all
namespaces. This is technically unnecessary, I think, it could just do
so for the moved ns. I think this is a bit confusing but also probably
harmless.

Closes https://github.com/benedekfazekas/mranderson/issues/78