### PR TITLE
Exclude clj-kondo.exports from jar extraction

### DIFF
--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -29,7 +29,8 @@
          entries (enumeration-seq (.entries zip))
          entry-pred (fn entry-pred [^java.util.zip.ZipEntry entry]
                       (not (or (.isDirectory entry)
-                               (str/includes? (str entry) "META-INF"))))]
+                               (str/includes? (str entry) "META-INF")
+                               (str/includes? (str entry) "clj-kondo.exports"))))]
      (doseq [entry entries
              :when (entry-pred entry)
              :let  [f (zip-target-file target-dir entry)]]


### PR DESCRIPTION
Libraries like http-kit 2.8.1 ship clj-kondo.exports directories in their jars. The unzip function extracts these and then tries to process them as regular source files, causing a `FileNotFoundException` during namespace rewriting (e.g. `target/srcdeps/httpkit/with_channel.clj`).

This adds `clj-kondo.exports` to the exclusion filter alongside the existing `META-INF` exclusion.