### PR TITLE
[Fixes #76] Consider `org.clojure/core.rrb-vector` part of clj core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [fix [#72](https://github.com/benedekfazekas/mranderson/issues/72)] Mranderson rewrites some clj/cljc files twice (instaparse)
 - [fix [#56](https://github.com/benedekfazekas/mranderson/issues/56)] Fix intermittent broken files when inlining
 - [fix [#90](https://github.com/benedekfazekas/mranderson/issues/90)] Fix spade/core.cljs not found
+- [fix [#76](https://github.com/benedekfazekas/mranderson/issues/76)] Consider `org.clojure/core.rrb-vector` as part of clojure.core
 
 ## Changes
 

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -316,7 +316,7 @@
 (defn- mranderson-unresolved-deps!
   "Unzips and transforms files in an unresolved dependency tree."
   [unresolved-deps-tree paths ctx]
-  (let [unresolved-deps-tree (t/evict-subtrees unresolved-deps-tree '#{org.clojure/clojure org.clojure/clojurescript})]
+  (let [unresolved-deps-tree (t/evict-subtrees unresolved-deps-tree '#{org.clojure/clojure org.clojure/clojurescript org.clojure/core.rrb-vector})]
     (log/info "in UNRESOLVED-TREE mode, working on an unresolved dependency tree")
     (t/walk-deps unresolved-deps-tree print-dep)
     (t/walk-dep-tree unresolved-deps-tree unzip-artifact! update-artifact! paths ctx)))


### PR DESCRIPTION
and never mranderson it.
Fixes inlining issues with clojure.core itself when rrb-vector is inlined