### PR TITLE
Add a Leiningen-free entry point for tools.build users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Changes
 
+- [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] add `mranderson.core/inline-deps`, a Leiningen-free entry point usable from `tools.build`/`tools.deps`
 - [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] uncouple MrAnderson from leiningen to support general use 
 - [maint [#66](https://github.com/benedekfazekas/mranderson/issues/66)] bump MrAnderson dependencies
 - [fix [#63](https://github.com/benedekfazekas/mranderson/pull/63)] introduce `mranderson.internal.no-parallelism` as on option temporarily

--- a/README.md
+++ b/README.md
@@ -53,6 +53,49 @@ Release to clojars
 
 Alternatively the modified dependencies and project files can be copied back to the source tree and stored in version control. In this case you don't need the above mentioned built in leiningen profile.
 
+### Using MrAnderson without Leiningen (tools.deps / tools.build)
+
+You don't need Leiningen to run MrAnderson. The `mranderson.core/inline-deps`
+function is a plain, data-driven entry point that does the same work as the
+`lein inline-deps` task. It's handy when your project is built with
+[tools.build](https://clojure.org/guides/tools_build).
+
+Add MrAnderson to a build alias in `deps.edn`:
+
+```clojure
+{:aliases
+ {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
+                 thomasa/mranderson {:mvn/version "0.5.4"}}
+          :ns-default build}}}
+```
+
+and call it from your `build.clj`:
+
+```clojure
+(ns build
+  (:require [mranderson.core :as mranderson]))
+
+(defn inline-deps [_]
+  (mranderson/inline-deps
+   {:project-prefix "com.example.inlined"
+    :source-paths   ["src"]
+    :dependencies   '[[org.clojure/tools.namespace "1.5.1"]
+                      [org.clojure/tools.reader "1.6.0"]]}))
+```
+
+Unlike the Leiningen plugin, every coordinate in `:dependencies` is inlined, so
+there's no need to tag them with `^:inline-dep`. The shadowed sources land in
+`target/srcdeps`, which you then put on the classpath when building your jar.
+
+`inline-deps` doubles as a Clojure CLI tool function, so you can also invoke it
+directly:
+
+```
+clojure -T:build inline-deps
+```
+
+See the docstring of `mranderson.core/inline-deps` for the full list of options.
+
 ## Config and options
 
 ### Two modes: resolved tree and unresolved tree

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -376,3 +376,109 @@
       (class-deps-jar!)
       (u/apply-jarjar! pname pversion)
       (replace-class-deps!))))
+
+(def default-repositories
+  "Maven repositories used to resolve dependencies when none are supplied."
+  [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
+   ["clojars" {:url "https://repo.clojars.org/"}]])
+
+(defn- default-project-prefix []
+  (str "mranderson" (subs (str (UUID/randomUUID)) 0 8)))
+
+(defn- mark-inline
+  "Every entry in `:dependencies` is meant to be inlined, so tag each coordinate
+  with the `^:inline-dep` meta that `mranderson` filters on. This spares callers
+  from having to remember the meta tag (which is also awkward to express via the
+  CLI)."
+  [dependencies]
+  (mapv #(vary-meta % assoc :inline-dep true) dependencies))
+
+(defn inline-deps
+  "Inline and shadow `:dependencies` so they cannot interfere with the
+  dependencies of downstream consumers.
+
+  This is the Leiningen-free counterpart of the `leiningen.inline-deps` plugin
+  task: it takes a plain options map instead of a Leiningen project map, which
+  makes it usable from a `tools.build` build script:
+
+      (require '[mranderson.core :as mranderson])
+      (mranderson/inline-deps
+       {:project-prefix \"com.example.inlined\"
+        :source-paths   [\"src\"]
+        :dependencies   '[[org.clojure/tools.namespace \"1.5.1\"]]})
+
+  or directly as a Clojure CLI tool function (`clojure -T:mranderson inline-deps`).
+
+  The project's own `:source-paths` and the resolved dependency sources are
+  copied into `<target-path>/srcdeps`, with the dependency namespaces (and
+  references to them, including those in the project's own sources) rewritten
+  under `:project-prefix`.
+
+  Options:
+
+  - `:dependencies`    (required) vector of `[lib version & kvs]` coordinates to
+                       inline. Every entry is treated as an inline dep, so there
+                       is no need to attach `^:inline-dep` meta yourself.
+  - `:source-paths`    (required) the project's own source directories to copy
+                       into `srcdeps` and rewrite.
+  - `:project-prefix`  namespace/path prefix for the shadowed deps. Defaults to a
+                       random `mranderson<hex>` prefix; set a stable value for
+                       reproducible output.
+  - `:target-path`     build target directory. Defaults to `\"target\"`; output is
+                       written to `<target-path>/srcdeps`.
+  - `:repositories`    Maven repositories used for resolution. Defaults to Maven
+                       Central and Clojars (see `default-repositories`).
+  - `:pname`           project name, used when repackaging bundled Java classes.
+                       Defaults to `\"mranderson\"`.
+  - `:pversion`        project version, used when repackaging bundled Java
+                       classes. Defaults to `\"0.0.0\"`.
+  - `:skip-repackage-java-classes` skip jarjar repackaging of bundled `.class`
+                       files. Defaults to `false`.
+  - `:prefix-exclusions` seq of prefixes to leave untouched when rewriting Java
+                       imports.
+  - `:unresolved-tree` use unresolved-tree mode (deeply nested isolation).
+                       Defaults to `false`.
+  - `:overrides`       overrides for unresolved-tree mode.
+  - `:expositions`     transitive deps to expose to the project's sources in
+                       unresolved-tree mode.
+  - `:watermark`       meta key marking inlined namespaces. Defaults to
+                       `:mranderson/inlined`.
+
+  Returns the resolved project prefix (handy when it was generated)."
+  [{:keys [dependencies source-paths project-prefix target-path repositories
+           pname pversion skip-repackage-java-classes prefix-exclusions
+           unresolved-tree overrides expositions watermark]
+    :or   {target-path                 "target"
+           repositories                default-repositories
+           pname                       "mranderson"
+           pversion                    "0.0.0"
+           skip-repackage-java-classes false
+           unresolved-tree             false
+           watermark                   :mranderson/inlined}}]
+  (assert (seq dependencies) ":dependencies must be a non-empty collection")
+  (assert (seq source-paths) ":source-paths must be a non-empty collection")
+  (let [target-path (str target-path)
+        pprefix     (or (some-> project-prefix name) (default-project-prefix))]
+    ;; The project's own sources have to live next to the inlined deps so that
+    ;; their references can be rewritten too.
+    (copy-source-files source-paths target-path)
+    (let [srcdeps             (str target-path "/srcdeps")
+          ;; At this point srcdeps only holds the copied project sources; the
+          ;; prefix dir for the deps does not exist yet.
+          project-source-dirs (filter fs/directory? (or (.listFiles (io/file srcdeps)) []))
+          ctx                 {:pname                       pname
+                               :pversion                    (str pversion)
+                               :pprefix                     pprefix
+                               :skip-repackage-java-classes skip-repackage-java-classes
+                               :srcdeps                     srcdeps
+                               :prefix-exclusions           prefix-exclusions
+                               :project-source-dirs         project-source-dirs
+                               :unresolved-tree             unresolved-tree
+                               :overrides                   overrides
+                               :expositions                 expositions
+                               :watermark                   watermark}
+          paths               {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
+                               :parent-clj-dirs []
+                               :branch          []}]
+      (mranderson repositories (mark-inline dependencies) ctx paths)
+      pprefix)))

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -1,6 +1,7 @@
 (ns mranderson.core-test
   (:require [mranderson.core :as sut]
             [mranderson.test :refer [with-mranderson]]
+            [mranderson.util :as util]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.test :refer [deftest testing is]]
@@ -111,3 +112,62 @@
 
         (finally
           (cleanup!))))))
+
+(defn- temp-dir [prefix]
+  (doto (File/createTempFile prefix "")
+    (.delete)
+    (.mkdirs)))
+
+(deftest t-inline-deps
+  (let [src    (temp-dir "mranderson-inline-src")
+        target (temp-dir "mranderson-inline-target")
+        main   (io/file src "mrt" "main.clj")]
+    (try
+      (.mkdirs (.getParentFile main))
+      (spit main "(ns mrt.main (:require [riddley.walk :as rw]))")
+      (let [prefix  (sut/inline-deps
+                     {:dependencies                '[[riddley "0.1.12"]]
+                      :source-paths                [(str src)]
+                      :target-path                 (str target)
+                      :project-prefix              "mranderson.inline.test"
+                      :skip-repackage-java-classes true})
+            srcdeps (io/file target "srcdeps")]
+
+        (testing "returns the resolved project prefix"
+          (is (= "mranderson.inline.test" prefix)))
+
+        (testing "the inlined dependency is shadowed under the prefix"
+          (let [walk (io/file srcdeps "mranderson" "inline" "test"
+                              "riddley" "v0v1v12" "riddley" "walk.clj")]
+            (is (.exists walk))
+            (is (string/starts-with?
+                 (slurp walk)
+                 "(ns ^{:mranderson/inlined true} mranderson.inline.test.riddley.v0v1v12.riddley.walk"))))
+
+        (testing "references in the project's own sources are rewritten"
+          (let [copied (io/file srcdeps "mrt" "main.clj")]
+            (is (.exists copied))
+            (is (string/includes?
+                 (slurp copied)
+                 "mranderson.inline.test.riddley.v0v1v12.riddley.walk")))))
+      (finally
+        (fs/delete-dir src)
+        (fs/delete-dir target)))))
+
+(deftest t-inline-deps-generates-a-prefix-when-none-is-given
+  (let [src    (temp-dir "mranderson-inline-src")
+        target (temp-dir "mranderson-inline-target")
+        main   (io/file src "mrt" "main.clj")]
+    (try
+      (.mkdirs (.getParentFile main))
+      (spit main "(ns mrt.main (:require [riddley.walk :as rw]))")
+      (let [prefix (sut/inline-deps
+                    {:dependencies                '[[riddley "0.1.12"]]
+                     :source-paths                [(str src)]
+                     :target-path                 (str target)
+                     :skip-repackage-java-classes true})]
+        (is (string/starts-with? prefix "mranderson"))
+        (is (.exists (io/file target "srcdeps" (util/sym->file-name prefix)))))
+      (finally
+        (fs/delete-dir src)
+        (fs/delete-dir target)))))


### PR DESCRIPTION
The inlining machinery is already lein-agnostic at runtime, but the only public way to drive it has been the `leiningen.inline-deps` plugin task. That forces tools.build/tools.deps users to hand-reproduce the glue that builds the ctx/paths maps, picks a prefix, copies the project sources and computes the project source dirs.

This adds `mranderson.core/inline-deps`, a plain options-map entry point that packages all of that, so a `build.clj` can inline deps with a single call (it also works as a `-T` tool fn). Every coordinate in `:dependencies` is inlined, so callers don't need the `^:inline-dep` meta tag. Comes with tests and a README section.

Addresses part of #42. The motivation is migrating cider-nrepl (and the rest of the nREPL/clojure-emacs projects) off Leiningen onto tools.deps while keeping shading.

Proven downstream in clojure-emacs/cider-nrepl#980, which uses this entry point to drive its shading from `build.clj`.