### PR TITLE
Strip non-alphanumeric chars from generated prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 
+- [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
 - [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name
 - [fix [#49](https://github.com/benedekfazekas/mranderson/issues/49)] Options accepted from both CLI and the project map

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -83,9 +83,14 @@
                 ((partial conj %1))) #{} (class-files)))
 
 (defn clean-name-version
+  "Builds an identifier-safe prefix out of `pname` and `pversion`.
+
+  Strips every non-alphanumeric character so that names or versions
+  containing characters like `/` (e.g. a version of \"n/a\") don't leak
+  into the generated package/namespace prefix and break imports."
   [pname pversion]
-  (str (str/replace pname #"[\._-]" "")
-       (str/replace pversion #"[\._-]" "")))
+  (str (str/replace pname #"[^a-zA-Z0-9]" "")
+       (str/replace pversion #"[^a-zA-Z0-9]" "")))
 
 (defn first-src-path [root source-paths]
   (apply str (drop (inc (count root)) (first source-paths))))

--- a/test/mranderson/util_test.clj
+++ b/test/mranderson/util_test.clj
@@ -4,6 +4,14 @@
             [clojure.java.io :as io]
             [clojure.test :as t]))
 
+(t/deftest clean-name-version-test
+  (t/are [expected pname pversion] (= expected (util/clean-name-version pname pversion))
+    "mranderson010"   "mranderson"  "0.1.0"
+    "mranderson010"   "mr-anderson" "0.1.0"
+    ;; a "n/a" version must not leak the slash into the prefix (see #64)
+    "mrandersonna"    "mranderson"  "n/a"
+    "mranderson000"   "mranderson"  "0.0.0"))
+
 (t/deftest duplicated-files-test
   (t/is (= {}
            (util/duplicated-files [(str (fs/file "a" "b" "c"))


### PR DESCRIPTION
When a project's version is something like `n/a`, the slash leaked into the prefix used for repackaging Java classes and rewriting imports, producing invalid namespaces and a confusing import error. We now strip any non-alphanumeric character so the prefix is always a valid identifier segment.

Fixes #64.