### PR TITLE
Warn when :aot is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ## Changes
 
+- [#89](https://github.com/benedekfazekas/mranderson/issues/89) Warn when `:aot` is configured, since inlining AOT-compiled namespaces produces broken prefixes
 - [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] add `mranderson.core/inline-deps`, a Leiningen-free entry point usable from `tools.build`/`tools.deps`
 - [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] uncouple MrAnderson from leiningen to support general use 
 - [maint [#66](https://github.com/benedekfazekas/mranderson/issues/66)] bump MrAnderson dependencies

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -20,6 +20,18 @@
                          str
                          (.substring 0 8))))
 
+(defn- aot-configured? [aot]
+  (or (= :all aot)
+      (and (coll? aot) (seq aot))))
+
+(defn- warn-on-aot
+  "AOT compilation produces `.class` files for the project and its deps. When
+  inlining those, MrAnderson can end up repeating the prefix on already-compiled
+  namespaces (see #89), so warn the user that disabling `:aot` avoids the trouble."
+  [{:keys [aot]}]
+  (when (aot-configured? aot)
+    (log/warn "WARNING: `:aot` is set in this project. Inlining AOT-compiled namespaces is known to produce broken prefixes (see https://github.com/benedekfazekas/mranderson/issues/89). Consider disabling `:aot` while inlining dependencies.")))
+
 (defn- lein-project->ctx
   [{:keys [root target-path name version mranderson]} args]
   (let [cli-opts                    (map edn/read-string args)
@@ -60,6 +72,7 @@
   :prefix-exclusions        list      List of prefixes that should not be processed in imports
   :unresolved-tree          boolean   Enforces unresolved tree mode"
   [{:keys [repositories dependencies target-path] :as project} & args]
+  (warn-on-aot project)
   (c/copy-source-files (u/determine-source-dirs project) target-path)
   (let [{:keys [pprefix] :as ctx} (lein-project->ctx project args)
         paths                     (initial-paths target-path pprefix)]

--- a/test/leiningen/inline_deps_test.clj
+++ b/test/leiningen/inline_deps_test.clj
@@ -1,0 +1,14 @@
+(ns leiningen.inline-deps-test
+  (:require [leiningen.inline-deps :as inline-deps]
+            [clojure.test :as t]))
+
+(def ^:private aot-configured? #'inline-deps/aot-configured?)
+
+(t/deftest aot-configured?-test
+  (t/are [expected aot] (= expected (boolean (aot-configured? aot)))
+    false nil
+    false []
+    false '()
+    true  :all
+    true  '[my.ns.one my.ns.two]
+    true  '[my.ns.one]))


### PR DESCRIPTION
Inlining AOT-compiled namespaces makes MrAnderson repeat the project prefix on already-compiled files, yielding namespaces like `mylib.mylib.mylib.some.ns`. We can't reliably fix the compiled artifacts, but we can warn the user that disabling `:aot` while inlining avoids the trouble, which is the approach folks landed on in the issue thread.

Fixes #89.