### PR TITLE
Add developer build/install docs and fix Makefile install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## Changes
 
 - [#89](https://github.com/benedekfazekas/mranderson/issues/89) Warn when `:aot` is configured, since inlining AOT-compiled namespaces produces broken prefixes
+- [#69](https://github.com/benedekfazekas/mranderson/issues/69) Document the local build/install workflow and fix the `Makefile` so `make install` installs an inlined MrAnderson to the local maven repo
 - [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] add `mranderson.core/inline-deps`, a Leiningen-free entry point usable from `tools.build`/`tools.deps`
 - [feature [#42](https://github.com/benedekfazekas/mranderson/issues/42)] uncouple MrAnderson from leiningen to support general use 
 - [maint [#66](https://github.com/benedekfazekas/mranderson/issues/66)] bump MrAnderson dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-.PHONY: install inline test integration-test deploy clean
+.PHONY: bootstrap-install inline test integration-test install deploy clean
 
-# Note that `install` is a two-step process: given that mranderson depends on itself as a plugin,
-# it first needs to be installed without the plugin, for bootstrapping this self dependency.
-install:
+# Note that bootstrapping is a two-step process: given that mranderson depends on
+# itself as a plugin, it first needs to be installed without the plugin, so that
+# the self dependency can be resolved.
+bootstrap-install:
 	lein clean
 	lein with-profile -user,-dev install
 	lein with-profile -user,-dev,+mranderson-plugin install
 
-.inline: install
+.inline: bootstrap-install
 	rm target/*.jar
 	rm pom.xml
 	lein with-profile -user,-dev,+mranderson-plugin inline-deps :skip-javaclass-repackage true
@@ -20,6 +21,11 @@ test:
 
 integration-test:
 	scripts/integration_test.sh
+
+# Install mranderson, with its own dependencies inlined, to the local maven
+# repository so that other projects can depend on it.
+install: .inline
+	lein with-profile -user,-dev,+mranderson-profile install
 
 deploy: .inline
 	lein with-profile -user,-dev,+mranderson-profile deploy clojars

--- a/README.md
+++ b/README.md
@@ -265,6 +265,24 @@ MrAnderson is tested and supported on Linux and macOS. Windows systems are not s
 - [iced-nrepl](https://github.com/liquidz/iced-nrepl)
 - [conjure](https://github.com/Olical/conjure) via [conjure-deps](https://github.com/Olical/conjure-deps) -- uses MrAnderson directly, not as a `leiningen` plugin
 
+## Development
+
+MrAnderson is a bit unusual to build because it inlines its own dependencies
+using itself, so it depends on itself as a Leiningen plugin. The `Makefile`
+wraps the moving parts:
+
+- `make test` runs the unit tests.
+- `make integration-test` runs the integration tests (against `cider-nrepl` and
+  `refactor-nrepl`, see `scripts/integration_test.sh`).
+- `make bootstrap-install` installs MrAnderson to your local maven repository
+  *without* inlining, which is needed to satisfy the self-dependency on the
+  plugin.
+- `make inline` bootstraps and then produces an inlined build under
+  `target/srcdeps`.
+- `make install` installs an inlined MrAnderson to your local maven repository,
+  so other projects on your machine can depend on it.
+- `make deploy` deploys an inlined release to Clojars.
+
 ## Related project
 
 A really nice wrapper of mranderson can be found [here](https://github.com/xsc/lein-isolate).


### PR DESCRIPTION
Building MrAnderson locally is non-obvious because it inlines its own deps using itself. This adds a short Development section to the README explaining the make targets, and reworks the Makefile so `make install` actually installs an inlined build to the local maven repo - the old `install` target only did the bootstrap step. Approach matches what @lread verified in the issue.

Fixes #69.