### PR TITLE
Fix class/record references when the prefix contains a dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 
+- [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
 - [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -237,6 +237,20 @@
       (recur found-node)
       (z/root-string loc))))
 
+(defn- class-reference?
+  "True if `match`, a fully-qualified dotted symbol (the reader splits on `/`, so
+  these never contain a slash), refers to a Java class/record rather than a
+  namespace or var. Clojure class names are CamelCase, so we treat a final
+  segment that starts with an uppercase letter as a class. A trailing dot
+  (constructor form, e.g. `foo.Bar.`) is ignored."
+  [match]
+  (let [last-seg (-> match
+                     (str/replace #"\.$" "")
+                     (str/split #"\.")
+                     last)]
+    (and (seq last-seg)
+         (Character/isUpperCase ^char (first last-seg)))))
+
 (defn- source-replacement [old-sym new-sym match]
   (let [old-ns-ref      (name old-sym)
         new-ns-ref      (name new-sym)
@@ -259,7 +273,13 @@
       (str/replace match old-type-prefix new-type-prefix)
 
       (str/starts-with? match old-ns-ref-dot)
-      (str/replace match old-ns-ref-dot new-ns-ref-dot)
+      (let [replaced (str/replace match old-ns-ref-dot new-ns-ref-dot)]
+        ;; A fully-qualified class/record reference compiles to a Java package,
+        ;; so any dash introduced by the new prefix must become an underscore.
+        ;; A namespace/var reference keeps the dashes. See #73.
+        (if (class-reference? match)
+          (java-package replaced)
+          replaced))
 
       :default
       match)))

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -340,3 +340,37 @@
   (t/is (= (s-rename-ns "(ns #_#_ skip1 skip2 ^:boop #_ skip3 foo)" 'foo 'bar :mranderson/zing)
            "(ns #_#_ skip1 skip2 ^{:boop true :mranderson/zing true} #_ skip3 bar)")
         "uneval nodes are skipped"))
+
+(def ^:private replace-in-source #'sut/replace-in-source)
+
+(t/deftest replace-in-source-test
+  ;; when the new namespace prefix contains a dash (e.g. a project-prefix like
+  ;; `cider.nrepl.inlined-deps`), a fully-qualified class/record reference must
+  ;; have its package part munged to Java style (dashes -> underscores), while a
+  ;; namespace/var reference keeps the dashes. See #73.
+  (let [old-sym 'instaparse.gll
+        new-sym 'cider.nrepl.inlined-deps.instaparse.gll]
+    (t/are [expected source] (= expected (replace-in-source source old-sym new-sym))
+      ;; fully-qualified record/class reference -> underscored package
+      "cider.nrepl.inlined_deps.instaparse.gll.Failure"
+      "instaparse.gll.Failure"
+
+      ;; constructor form keeps the trailing dot, still underscored
+      "(cider.nrepl.inlined_deps.instaparse.gll.Failure. tree)"
+      "(instaparse.gll.Failure. tree)"
+
+      ;; instance? check on a fully-qualified record -> underscored package
+      "(instance? cider.nrepl.inlined_deps.instaparse.gll.Failure x)"
+      "(instance? instaparse.gll.Failure x)"
+
+      ;; a namespaced var reference keeps the dashes
+      "cider.nrepl.inlined-deps.instaparse.gll/parse"
+      "instaparse.gll/parse"
+
+      ;; a deeper sub-namespace (lowercase last segment) keeps the dashes
+      "cider.nrepl.inlined-deps.instaparse.gll.core"
+      "instaparse.gll.core"
+
+      ;; the bare namespace itself keeps the dashes
+      "cider.nrepl.inlined-deps.instaparse.gll"
+      "instaparse.gll")))


### PR DESCRIPTION
When the inlining prefix contains a dash (Cider, for instance, uses `cider.nrepl.inlined-deps`), a fully-qualified record or class reference in a namespace body - say `instaparse.gll.Failure` - was rewritten keeping the dash, which is an invalid class reference. A class reference compiles down to a Java package, so the dashes in its package need to become underscores; a namespace or var reference keeps them. We tell the two apart by the shape of the token, the same way Clojure's reader does (no slash + CamelCase final segment means it's a class).

Fixes #73.