### PR TITLE
Don't clobber project sources when repackaging Java classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
+- [fix [#88](https://github.com/benedekfazekas/mranderson/issues/88)] When removing a dependency's compiled classes, only delete `.class` files instead of the whole top-level directory, so project sources sharing a root namespace with an inlined lib aren't clobbered
 - [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name
 - [fix [#49](https://github.com/benedekfazekas/mranderson/issues/49)] Options accepted from both CLI and the project map

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -8,7 +8,8 @@
             [mranderson.move :as move]
             [mranderson.log :as log]
             [mranderson.util :as u])
-  (:import java.util.UUID
+  (:import java.io.File
+           java.util.UUID
            [java.util.zip ZipEntry ZipFile ZipOutputStream]))
 
 ;; inlined from leiningen source
@@ -153,11 +154,30 @@
             (flush)
             (.closeEntry zip)))))))
 
+(defn- delete-class-files!
+  "Deletes the `.class` files under `dir`, then prunes any directories left
+  empty. Other files (notably `.clj`/`.cljc`/`.cljs` sources) are preserved, so
+  a dependency's compiled classes can be removed before unpacking the repackaged
+  ones without clobbering sibling sources that happen to share a top-level
+  directory with them, e.g. when an inlined lib's root namespace matches the
+  project's own (see #88)."
+  [^File dir]
+  (when (.isDirectory dir)
+    ;; reverse of the pre-order file-seq visits children before their parents,
+    ;; so a directory is only checked for emptiness once its class files are gone
+    (doseq [^File f (reverse (file-seq dir))]
+      (cond
+        (and (.isFile f) (str/ends-with? (.getName f) ".class"))
+        (.delete f)
+
+        (and (.isDirectory f) (empty? (.listFiles f)))
+        (.delete f)))))
+
 (defn- replace-class-deps! []
-  (log/info "deleting directories with class files in target/srcdeps...")
+  (log/info "deleting class files in target/srcdeps...")
   (doseq [class-dir (u/java-class-dirs)]
-    (fs/delete-dir (str "target/srcdeps/" class-dir))
-    (log/info "  " class-dir " deleted"))
+    (delete-class-files! (fs/file "target/srcdeps" class-dir))
+    (log/info "  " class-dir " class files deleted"))
   (log/info "unzipping repackaged class-deps.jar into target/srcdeps")
   (unzip (fs/file "target/class-deps.jar") (fs/file "target/srcdeps/")))
 

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -118,6 +118,37 @@
     (.delete)
     (.mkdirs)))
 
+(def ^:private delete-class-files! #'sut/delete-class-files!)
+
+(deftest t-delete-class-files
+  (let [root (temp-dir "mranderson-delete-class")]
+    (try
+      ;; a dependency's compiled classes...
+      (spit (doto (io/file root "full" "json.class") (-> .getParentFile .mkdirs)) "")
+      (spit (io/file root "full" "json$fn.class") "")
+      ;; ...sharing a top-level dir with the project's own sources (see #88)
+      (spit (doto (io/file root "full" "aws" "core.clj") (-> .getParentFile .mkdirs)) "(ns full.aws.core)")
+      ;; a dir that holds nothing but class files
+      (spit (doto (io/file root "only" "classes" "A.class") (-> .getParentFile .mkdirs)) "")
+
+      (delete-class-files! (io/file root "full"))
+      (delete-class-files! (io/file root "only"))
+
+      (testing "class files are removed"
+        (is (not (.exists (io/file root "full" "json.class"))))
+        (is (not (.exists (io/file root "full" "json$fn.class"))))
+        (is (not (.exists (io/file root "only" "classes" "A.class")))))
+
+      (testing "sibling source files are preserved"
+        (is (.exists (io/file root "full" "aws" "core.clj")))
+        (is (= "(ns full.aws.core)" (slurp (io/file root "full" "aws" "core.clj")))))
+
+      (testing "directories left empty are pruned"
+        (is (not (.exists (io/file root "only")))))
+
+      (finally
+        (fs/delete-dir root)))))
+
 (deftest t-inline-deps
   (let [src    (temp-dir "mranderson-inline-src")
         target (temp-dir "mranderson-inline-target")


### PR DESCRIPTION
After jarjar repackages a dependency's Java classes, mranderson deletes the originals so the prefixed ones can take their place. It did that by deleting the whole top-level directory (`target/srcdeps/full`, say). If an inlined lib ships AOT-compiled `.class` files whose root package matches the consuming project's own root namespace, that delete also wipes the project's sources - which is the full.json-from-full.aws case in the issue, where `target/srcdeps/full/aws` vanishes.

This deletes only the `.class` files and prunes directories left empty, leaving sibling sources alone. Note that inlining AOT'd libs is still fragile in general (see #89); this just stops the data loss.

Fixes #88.