### PR TITLE
Test the Java import-rewriting logic

### DIFF
--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -188,6 +188,36 @@
          (map (partial str "target/srcdeps/")))
     []))
 
+(defn- prefix-occurrences
+  "Prefixes each token in `tokens` with `cleaned-name-version` wherever it occurs
+  in `s` and is not already preceded by a dot (so an occurrence that is already
+  part of a longer, prefixed name is left alone)."
+  [s tokens cleaned-name-version]
+  (reduce (fn [acc token]
+            (str/replace acc
+                         (re-pattern (str "([^\\.])" token))
+                         (str "$1" cleaned-name-version "." token)))
+          s
+          tokens))
+
+(defn- rewrite-java-imports
+  "Rewrites `content` so references to repackaged Java classes are prefixed with
+  `cleaned-name-version`. Inside the `(:import …)` fragment (`orig-import`) the
+  classes are listed bare under their package, so packages are prefixed there;
+  in the rest of the file classes appear fully qualified, so the exact class
+  names are prefixed. The import fragment is swapped out for a placeholder while
+  the body is rewritten so it isn't processed twice. Returns `content` unchanged
+  when `orig-import` is blank."
+  [content orig-import class-names package-names cleaned-name-version]
+  (if (str/blank? orig-import)
+    content
+    (let [new-import (prefix-occurrences orig-import package-names cleaned-name-version)
+          uuid       (str (UUID/randomUUID))]
+      (-> content
+          (str/replace orig-import uuid)
+          (prefix-occurrences class-names cleaned-name-version)
+          (str/replace uuid new-import)))))
+
 (defn- prefix-dependency-imports! [pname pversion pprefix prefix src-path srcdeps]
   (let [cleaned-name-version (u/clean-name-version pname pversion)
         prefix (some-> (first prefix)
@@ -213,13 +243,9 @@
       (doseq [file clj-files]
         (let [old         (slurp (fs/file file))
               orig-import (find-orig-import imports file)
-              new-import  (reduce #(str/replace %1 (re-pattern (str "([^\\.])" %2)) (str "$1" cleaned-name-version "." %2)) orig-import package-names)
-              uuid        (str (UUID/randomUUID))
-              new         (str/replace old orig-import uuid)
-              new         (reduce #(str/replace %1 (re-pattern (str "([^\\.])" %2)) (str "$1" cleaned-name-version "." %2)) new class-names)
-              new         (str/replace new uuid new-import)]
+              new         (rewrite-java-imports old orig-import class-names package-names cleaned-name-version)]
           (when-not (= old new)
-            (log/debug "file: " file " orig import:" orig-import " new import:" new-import)
+            (log/debug "file: " file " orig import:" orig-import " new import:" (prefix-occurrences orig-import package-names cleaned-name-version))
             (spit file new))))
       (log/info "    prefixing imports: done"))))
 

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -113,6 +113,78 @@
         (finally
           (cleanup!))))))
 
+(def ^:private prefix-occurrences #'sut/prefix-occurrences)
+(def ^:private rewrite-java-imports #'sut/rewrite-java-imports)
+(def ^:private import-fragment #'sut/import-fragment)
+
+(deftest t-import-fragment
+  (testing "extracts the (:import ...) form from a namespace declaration"
+    (is (= "(:import [com.example Widget])"
+           (import-fragment "(ns foo\n  (:import [com.example Widget]))\n(defn bar [])")))
+    (is (= "(:import [com.example Widget Gadget]\n           java.util.UUID)"
+           (import-fragment (str "(ns foo\n"
+                                 "  (:require [clojure.string :as str])\n"
+                                 "  (:import [com.example Widget Gadget]\n"
+                                 "           java.util.UUID))")))))
+  (testing "returns nil when there is no :import form"
+    (is (nil? (import-fragment "(ns foo (:require [clojure.string :as str]))")))))
+
+(deftest t-prefix-occurrences
+  (testing "prefixes each token, leaving occurrences already preceded by a dot alone"
+    (is (= "(PRE.com.example.Widget)"
+           (prefix-occurrences "(com.example.Widget)" ["com.example.Widget"] "PRE")))
+    (is (= "(PRE.com.example.Widget PRE.com.example.Gadget)"
+           (prefix-occurrences "(com.example.Widget com.example.Gadget)"
+                               ["com.example.Widget" "com.example.Gadget"] "PRE"))))
+  (testing "a token already preceded by a dot is not re-prefixed"
+    ;; the leading char before the token must not be a dot
+    (is (= "(a.com.example.Widget)"
+           (prefix-occurrences "(a.com.example.Widget)" ["com.example.Widget"] "PRE")))))
+
+(deftest t-rewrite-java-imports
+  (let [prefix "mrt010"]
+    (testing "fully-qualified import: package is prefixed in the import, class name in the body"
+      (let [content     (str "(ns foo\n"
+                             "  (:import [com.example Widget]))\n"
+                             "(defn make [] (com.example.Widget/create))")
+            orig-import "(:import [com.example Widget])"
+            class-names ["com.example.Widget"]
+            pkg-names   #{"com.example"}]
+        (is (= (str "(ns foo\n"
+                    "  (:import [mrt010.com.example Widget]))\n"
+                    "(defn make [] (mrt010.com.example.Widget/create))")
+               (rewrite-java-imports content orig-import class-names pkg-names prefix)))))
+
+    (testing "a blank import fragment leaves the content untouched"
+      (is (= "(ns foo)" (rewrite-java-imports "(ns foo)" "" ["com.example.Widget"] #{"com.example"} prefix))))
+
+    ;; The following two cases pin CURRENT (buggy) behavior so the structural
+    ;; import-rewrite fix has a regression net to flip. They are not the desired
+    ;; end state.
+    (testing "KNOWN BUG (#52): a class in a repackaged package but NOT itself repackaged is still prefixed"
+      ;; clj-tuple ships some `clojure.lang.*` class, so `clojure.lang` ends up in
+      ;; the package set; an unrelated import of core `clojure.lang.Var` should be
+      ;; left alone, but currently the whole package gets prefixed.
+      (let [content     "(ns riddley.compiler\n  (:import [clojure.lang Var Compiler]))"
+            orig-import "(:import [clojure.lang Var Compiler])"
+            class-names ["clojure.lang.Tuple"]   ;; the only actually-repackaged class
+            pkg-names   #{"clojure.lang"}]
+        (is (= "(ns riddley.compiler\n  (:import [mrt010.clojure.lang Var Compiler]))"
+               (rewrite-java-imports content orig-import class-names pkg-names prefix))
+            "currently over-prefixes; the fix should leave Var/Compiler untouched")))
+
+    (testing "KNOWN BUG (#33): a mixed import gets a single package prefix for classes that need different ones"
+      ;; In `[pkg Deftyped JavaClass]`, the deftype-generated class is prefixed by
+      ;; the namespace move (nested prefix) and the real java class by jarjar (flat
+      ;; prefix); the import form can only carry one package prefix today.
+      (let [content     "(ns user\n  (:import [com.acme.impl Deftyped JavaClass]))"
+            orig-import "(:import [com.acme.impl Deftyped JavaClass])"
+            class-names ["com.acme.impl.JavaClass"]
+            pkg-names   #{"com.acme.impl"}]
+        (is (= "(ns user\n  (:import [mrt010.com.acme.impl Deftyped JavaClass]))"
+               (rewrite-java-imports content orig-import class-names pkg-names prefix))
+            "currently applies one package prefix to both; the fix should split the import")))))
+
 (defn- temp-dir [prefix]
   (doto (File/createTempFile prefix "")
     (.delete)


### PR DESCRIPTION
Groundwork before fixing the Java `:import` bugs (#52, #33). That rewriting lived inline in `prefix-dependency-imports!` and had zero test coverage - every `core-test` runs with `:skip-repackage-java-classes true`, so the whole repackaging path never executes under test. That's a big part of why these import bugs have stuck around.

This pulls the pure string transformation out into `rewrite-java-imports`/`prefix-occurrences` and covers it (plus the `import-fragment` extractor) with unit tests. No behavior change. Two of the tests deliberately pin the *current buggy* output for #52 (over-prefixing a class that shares a package with a repackaged one) and #33 (a mixed deftype/java-class import getting a single package prefix), clearly marked as KNOWN BUG, so the structural fix that follows has a regression net to flip.

A full end-to-end test of jarjar repackaging additionally needs the hardcoded `target/` paths threaded through as `srcdeps` (the `drop 2` path helpers assume that layout); I'd do that decoupling as its own change.