### PR TITLE
Decouple Java-class repackaging from hardcoded target/ paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
+- Java-class repackaging now operates on the configured `srcdeps` directory instead of a hardcoded `target/srcdeps`, so it works with `mranderson.core/inline-deps` and a custom `:target-path`
 - [fix [#88](https://github.com/benedekfazekas/mranderson/issues/88)] When removing a dependency's compiled classes, only delete `.class` files instead of the whole top-level directory, so project sources sharing a root namespace with an inlined lib aren't clobbered
 - [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 
 - [fix [#53](https://github.com/benedekfazekas/mranderson/issues/53)] Fix inlining where one directory name in the library is a substring of an other directory name

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -139,17 +139,17 @@
       ""))
 
 (defn- class-deps-jar!
-  "creates jar containing the deps class files"
-  []
-  (log/info "jaring all class file dependencies into target/class-deps.jar")
-  (with-open [file (io/output-stream "target/class-deps.jar")
+  "creates `jar-file` containing the class files found under `srcdeps`"
+  [srcdeps jar-file]
+  (log/info "jaring all class file dependencies into" (str jar-file))
+  (with-open [file (io/output-stream jar-file)
               zip (ZipOutputStream. file)
               writer (io/writer zip)]
-    (let [class-files (u/class-files)]
+    (let [class-files (u/class-files srcdeps)]
       (binding [*out* writer]
         (doseq [class-file class-files]
           (with-open [input (io/input-stream class-file)]
-            (.putNextEntry zip (ZipEntry. (u/remove-2parents class-file)))
+            (.putNextEntry zip (ZipEntry. (u/srcdeps-relative srcdeps class-file)))
             (io/copy input zip)
             (flush)
             (.closeEntry zip)))))))
@@ -173,19 +173,19 @@
         (and (.isDirectory f) (empty? (.listFiles f)))
         (.delete f)))))
 
-(defn- replace-class-deps! []
-  (log/info "deleting class files in target/srcdeps...")
-  (doseq [class-dir (u/java-class-dirs)]
-    (delete-class-files! (fs/file "target/srcdeps" class-dir))
+(defn- replace-class-deps! [srcdeps jar-file]
+  (log/info "deleting class files in" (str srcdeps) "...")
+  (doseq [class-dir (u/java-class-dirs srcdeps)]
+    (delete-class-files! (fs/file srcdeps class-dir))
     (log/info "  " class-dir " class files deleted"))
-  (log/info "unzipping repackaged class-deps.jar into target/srcdeps")
-  (unzip (fs/file "target/class-deps.jar") (fs/file "target/srcdeps/")))
+  (log/info "unzipping repackaged" (str jar-file) "into" (str srcdeps))
+  (unzip (fs/file jar-file) (fs/file srcdeps)))
 
-(defn- filter-clj-files [imports package-names]
+(defn- filter-clj-files [imports package-names srcdeps]
   (if (seq package-names)
     (->> (filter (fn [[_ import]] (some #(str/includes? import %) package-names)) imports)
          (map first)
-         (map (partial str "target/srcdeps/")))
+         (map (partial str srcdeps "/")))
     []))
 
 (defn- prefix-occurrences
@@ -223,17 +223,17 @@
         prefix (some-> (first prefix)
                        (str/replace "-" "_")
                        (str/replace "." "/"))
-        clj-dep-path (u/relevant-clj-dep-path src-path prefix pprefix)
+        clj-dep-path (u/relevant-clj-dep-path srcdeps src-path prefix pprefix)
         clj-files (u/clojure-source-files-relative clj-dep-path)
         imports (->> clj-files
-                     (reduce #(conj %1 (retrieve-import srcdeps (u/remove-2parents %2))) [])
+                     (reduce #(conj %1 (retrieve-import srcdeps (u/srcdeps-relative srcdeps %2))) [])
                      (remove nil?)
                      doall)
-        class-names (map u/class-file->fully-qualified-name (u/class-files))
+        class-names (map (partial u/class-file->fully-qualified-name srcdeps) (u/class-files srcdeps))
         package-names (->> class-names
                            (map u/class-name->package-name)
                            set)
-        clj-files (filter-clj-files imports package-names)]
+        clj-files (filter-clj-files imports package-names srcdeps)]
     (when (seq clj-files)
       (log/info (format "    prefixing imports in clojure files in '%s' ..." (str/join ":" clj-dep-path)))
       (log/debug "      class-names" class-names)
@@ -409,7 +409,7 @@
   - expositions: transient dependencies made available for the project source files in unresolved tree mode
   - watermark: meta flag to mark inlined dependencies"
 
-  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides] :as ctx} paths]
+  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps] :as ctx} paths]
   (let [source-dependencies         (filter u/source-dep? dependencies)
         resolved-deps-tree          (dr/resolve-source-deps repositories source-dependencies)
         overrides                   (or (and unresolved-tree overrides) {})
@@ -418,10 +418,11 @@
     (if unresolved-tree
       (mranderson-unresolved-deps! unresolved-deps-tree paths ctx)
       (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))
-    (when-not (or skip-repackage-java-classes (empty? (u/class-files)))
-      (class-deps-jar!)
-      (u/apply-jarjar! pname pversion)
-      (replace-class-deps!))))
+    (when-not (or skip-repackage-java-classes (empty? (u/class-files srcdeps)))
+      (let [jar-file (fs/file (fs/parent srcdeps) "class-deps.jar")]
+        (class-deps-jar! srcdeps jar-file)
+        (u/apply-jarjar! pname pversion srcdeps jar-file)
+        (replace-class-deps! srcdeps jar-file)))))
 
 (def default-repositories
   "Maven repositories used to resolve dependencies when none are supplied."

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -35,23 +35,24 @@
       (str/replace "-" "_")
       (str/replace "." File/separator)))
 
-(defn relevant-clj-dep-path [src-path prefix pprefix]
-  (let [pprefix-path-frag (sym->file-name pprefix)]
+(defn relevant-clj-dep-path [srcdeps src-path prefix pprefix]
+  (let [pprefix-path-frag (sym->file-name pprefix)
+        srcdeps-root      (str srcdeps "/")]
     (if-not (str/ends-with? src-path pprefix-path-frag)
-      (vector (str "target/srcdeps/"
+      (vector (str srcdeps-root
                    pprefix-path-frag
                    (-> src-path
                        (str/split (re-pattern pprefix-path-frag))
                        last)))
-      [(str "target/srcdeps/" prefix)])))
+      [(str srcdeps-root prefix)])))
 
 (defn clojure-source-files [dirs]
   (->> dirs
        clojure-source-files-relative
        (map #(.getCanonicalFile ^File %))))
 
-(defn class-files []
-  (let [dir (io/file "target/srcdeps")
+(defn class-files [srcdeps]
+  (let [dir (io/file srcdeps)
         subdirs (some-> (.listFiles ^File dir) seq)]
     (->> subdirs
          (filter #(.isDirectory ^File %))
@@ -60,13 +61,23 @@
                     (and (.isFile file)
                          (.endsWith (.getName file) ".class")))))))
 
-(defn class-file->fully-qualified-name [file]
-  (->> (-> file
-           str
+(defn srcdeps-relative
+  "Returns the path of `file` relative to the `srcdeps` root, using forward
+  slashes. `file` is expected to live under `srcdeps`, as everything produced by
+  walking the srcdeps tree does."
+  ^String [srcdeps file]
+  (let [root (str srcdeps)
+        path (str file)]
+    (-> (if (str/starts-with? path root)
+          (subs path (count root))
+          path)
+        (str/replace #"^[/\\]+" ""))))
+
+(defn class-file->fully-qualified-name [srcdeps file]
+  (->> (-> (srcdeps-relative srcdeps file)
            (str/split #"\.")
            first
            (str/split #"/"))
-       (drop 2)
        (str/join ".")))
 
 (defn class-name->package-name [class-name]
@@ -75,12 +86,11 @@
        (str/join ".")))
 
 (defn java-class-dirs
-  "lists subdirs of target/srcdeps which contain .class files"
-  []
-  (reduce #(->> (str/split (str %2) #"/")
-                (drop 2)
+  "lists subdirs of `srcdeps` which contain .class files"
+  [srcdeps]
+  (reduce #(->> (str/split (srcdeps-relative srcdeps %2) #"/")
                 first
-                ((partial conj %1))) #{} (class-files)))
+                ((partial conj %1))) #{} (class-files srcdeps)))
 
 (defn clean-name-version
   "Builds an identifier-safe prefix out of `pname` and `pversion`.
@@ -105,19 +115,14 @@
     (. rule setResult (str name-version "." java-dir ".@1"))
     rule))
 
-(defn apply-jarjar! [pname pversion]
-  (let [java-dirs (java-class-dirs)
+(defn apply-jarjar! [pname pversion srcdeps jar-file]
+  (let [java-dirs (java-class-dirs srcdeps)
         name-version (clean-name-version pname pversion)
         rules (map (partial create-rule name-version) java-dirs)
         processor (JjMainProcessor. rules false false)
-        jar-file (io/file (str "target/class-deps.jar"))]
-    (log/info (format "prefixing %s in target/class-deps.jar with %s" java-dirs name-version))
+        jar-file (io/file jar-file)]
+    (log/info (format "prefixing %s in %s with %s" java-dirs jar-file name-version))
     (StandaloneJarProcessor/run jar-file jar-file processor)))
-
-(defn remove-2parents ^String [file]
-  (->> (str/split (str file) #"/")
-       (drop 2)
-       (str/join "/")))
 
 (defn mranderson-version []
   (let [v (-> (io/resource "mranderson/project.clj")

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -79,6 +79,30 @@
           (let [content (slurp (io/file working-directory prefix "instaparse" "v1v4v12" "instaparse" "transform.cljc"))]
            (is (string/starts-with? content (str "(ns " ns-prefix ".instaparse.v1v4v12.instaparse.transform")))))))))
 
+(deftest t-resolved-tree-repackages-java-classes
+  ;; cljfmt pulls in the pure-Java diffutils, so inlining it (without skipping
+  ;; the java-class repackaging) exercises the jarjar pipeline end to end. This
+  ;; only works now that the repackaging operates on the configured `srcdeps`
+  ;; (the temp dir) rather than a hardcoded `target/srcdeps`.
+  (with-mranderson
+    [project {:dependencies '[^:inline-dep [cljfmt "0.7.0"]]
+              :files        []
+              :opts         {:unresolved-tree false}}]
+    (let [{:keys [working-directory]} project
+          name-version    (util/clean-name-version "mranderson-test" "0.1.0-SNAPSHOT")
+          class-file?     (fn [^File f] (and (.isFile f) (string/ends-with? (.getName f) ".class")))
+          all-class-files (->> (file-seq working-directory) (filter class-file?))]
+
+      (testing "the dependency tree contributes java .class files"
+        (is (seq all-class-files)))
+
+      (testing "every remaining .class file lives under the repackaged prefix"
+        (is (every? #(string/includes? (str %) (str "/" name-version "/")) all-class-files)))
+
+      (testing "diffutils' difflib package was repackaged under the prefix, original removed"
+        (is (.exists (io/file working-directory name-version "difflib")))
+        (is (not (.exists (io/file working-directory "difflib"))))))))
+
 (deftest t-copy-source-files
   (testing "Can merge files across overlapping dirs"
     (let [dir-a "test-resources/a"

--- a/test/mranderson/util_test.clj
+++ b/test/mranderson/util_test.clj
@@ -11,6 +11,42 @@
     ;; a "n/a" version must not leak the slash into the prefix (see #64)
     "mrandersonna"    "mranderson"  "n/a"
     "mranderson000"   "mranderson"  "0.0.0"))
+(defn- temp-dir! []
+  (doto (java.io.File/createTempFile "mranderson-util" "")
+    (.delete)
+    (.mkdirs)))
+
+(t/deftest path-helpers-respect-srcdeps-root
+  ;; the repackaging path helpers used to assume a literal `target/srcdeps`
+  ;; layout (they dropped the first two path segments); they now take an
+  ;; explicit `srcdeps` root so they work with any target directory.
+  (let [srcdeps (temp-dir!)]
+    (try
+      (spit (doto (io/file srcdeps "full" "json.class") (-> .getParentFile .mkdirs)) "")
+      (spit (io/file srcdeps "full" "json$fn.class") "")
+      (spit (doto (io/file srcdeps "com" "example" "Widget.class") (-> .getParentFile .mkdirs)) "")
+      ;; a source file living under the same root must be ignored by class-files
+      (spit (doto (io/file srcdeps "full" "aws" "core.clj") (-> .getParentFile .mkdirs)) "(ns full.aws.core)")
+
+      (t/testing "srcdeps-relative strips the srcdeps prefix"
+        (t/is (= "full/json.class"
+                 (util/srcdeps-relative srcdeps (io/file srcdeps "full" "json.class")))))
+
+      (t/testing "class-files finds only the .class files under srcdeps"
+        (t/is (= #{"full/json.class" "full/json$fn.class" "com/example/Widget.class"}
+                 (set (map #(util/srcdeps-relative srcdeps %) (util/class-files srcdeps))))))
+
+      (t/testing "java-class-dirs lists the top-level dirs that hold class files"
+        (t/is (= #{"full" "com"} (util/java-class-dirs srcdeps))))
+
+      (t/testing "class-file->fully-qualified-name uses the srcdeps-relative path"
+        (t/is (= "com.example.Widget"
+                 (util/class-file->fully-qualified-name srcdeps (io/file srcdeps "com" "example" "Widget.class"))))
+        (t/is (= "full.json"
+                 (util/class-file->fully-qualified-name srcdeps (io/file srcdeps "full" "json.class")))))
+
+      (finally
+        (fs/delete-dir srcdeps)))))
 
 (t/deftest duplicated-files-test
   (t/is (= {}


### PR DESCRIPTION
The Java-class repackaging (`class-files`, `java-class-dirs`, `apply-jarjar!`, `class-deps-jar!`, `replace-class-deps!`, and the import prefixing) was hardcoded to `target/srcdeps` and `target/class-deps.jar`, and the path helpers `(drop 2)`'d assuming that exact layout. `:srcdeps` is already in the context (both the Lein plugin and `inline-deps` set `<target>/srcdeps`), so this threads it through and derives the jar path from its parent.

Two payoffs: repackaging now works with `inline-deps` and a custom `:target-path` (it previously looked in `target/` regardless), and the `with-mranderson` fixture can finally exercise the jarjar pipeline - which had **no** test coverage at all. Adds unit tests for the path helpers plus an end-to-end test that inlines cljfmt (which pulls the pure-Java diffutils) without skipping repackaging.

Production behavior is unchanged: with `srcdeps` = `target/srcdeps` the derived paths are identical to before.

Stacked on #105 (#88) and #106 - please merge those first; this rebases cleanly onto master once they land. This is the groundwork for the structural `:import` fix (#52/#33) that follows.