### PR TITLE
Rewrite Java imports by exact class, splitting mixed import groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
+- [fix [#52](https://github.com/benedekfazekas/mranderson/issues/52)] Rewrite Java `:import`s by exact class rather than by package, so a class that merely shares a package with a repackaged one is left untouched
+- [[#33](https://github.com/benedekfazekas/mranderson/issues/33)] Split a mixed `(:import [pkg A B])` so a deftype-generated class and a real Java class in the same package each get the correct prefix
 - Java-class repackaging now operates on the configured `srcdeps` directory instead of a hardcoded `target/srcdeps`, so it works with `mranderson.core/inline-deps` and a custom `:target-path`
 - [fix [#88](https://github.com/benedekfazekas/mranderson/issues/88)] When removing a dependency's compiled classes, only delete `.class` files instead of the whole top-level directory, so project sources sharing a root namespace with an inlined lib aren't clobbered
 - [fix [#78](https://github.com/benedekfazekas/mranderson/issues/78)] Fix watermarking moved namespaces 

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -1,5 +1,6 @@
 (ns mranderson.core
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.namespace.file :refer [read-file-ns-decl]]
             [me.raynes.fs :as fs]
@@ -200,18 +201,61 @@
           s
           tokens))
 
+(defn- rewrite-import-spec
+  "Rewrites a single `(:import …)` spec class-exactly, returning a seq of specs.
+
+  A prefix-list `[pkg C1 C2 …]` is split so only the classes actually in
+  `class-names` get the `prefix`-ed package, leaving the rest under the original
+  package. This both avoids prefixing classes that merely share a package with a
+  repackaged one (#52) and keeps deftype-generated classes - which are prefixed
+  separately by the namespace move - in their original group (#33). A
+  fully-qualified class symbol is prefixed iff it is in `class-names`."
+  [spec class-names prefix]
+  (cond
+    (vector? spec)
+    (let [pkg     (first spec)
+          classes (rest spec)]
+      (if (empty? classes)
+        [spec]
+        (let [grouped (group-by #(contains? class-names (str pkg "." %)) classes)
+              members (seq (get grouped true))
+              others  (seq (get grouped false))]
+          (cond-> []
+            others  (conj (into [pkg] others))
+            members (conj (into [(symbol (str prefix "." pkg))] members))))))
+
+    (symbol? spec)
+    [(if (contains? class-names (str spec))
+       (symbol (str prefix "." spec))
+       spec)]
+
+    :else
+    [spec]))
+
+(defn- rewrite-import-form
+  "Parses the `(:import …)` form text and rewrites each spec class-exactly,
+  splitting mixed prefix-lists. Returns the rewritten form as a string, or the
+  original text unchanged if it can't be parsed."
+  [orig-import class-names prefix]
+  (try
+    (let [form (edn/read-string orig-import)]
+      (pr-str (cons :import (mapcat #(rewrite-import-spec % class-names prefix) (rest form)))))
+    (catch Exception _
+      orig-import)))
+
 (defn- rewrite-java-imports
   "Rewrites `content` so references to repackaged Java classes are prefixed with
-  `cleaned-name-version`. Inside the `(:import …)` fragment (`orig-import`) the
-  classes are listed bare under their package, so packages are prefixed there;
-  in the rest of the file classes appear fully qualified, so the exact class
-  names are prefixed. The import fragment is swapped out for a placeholder while
-  the body is rewritten so it isn't processed twice. Returns `content` unchanged
-  when `orig-import` is blank."
-  [content orig-import class-names package-names cleaned-name-version]
+  `cleaned-name-version`. The `(:import …)` fragment (`orig-import`) is parsed and
+  rewritten class-exactly (see `rewrite-import-spec`); in the rest of the file
+  classes appear fully qualified, so the exact class names are prefixed. The
+  import fragment is swapped out for a placeholder while the body is rewritten so
+  it isn't processed twice. Returns `content` unchanged when `orig-import` is
+  blank."
+  [content orig-import class-names cleaned-name-version]
   (if (str/blank? orig-import)
     content
-    (let [new-import (prefix-occurrences orig-import package-names cleaned-name-version)
+    (let [class-set  (set class-names)
+          new-import (rewrite-import-form orig-import class-set cleaned-name-version)
           uuid       (str (UUID/randomUUID))]
       (-> content
           (str/replace orig-import uuid)
@@ -243,9 +287,9 @@
       (doseq [file clj-files]
         (let [old         (slurp (fs/file file))
               orig-import (find-orig-import imports file)
-              new         (rewrite-java-imports old orig-import class-names package-names cleaned-name-version)]
+              new         (rewrite-java-imports old orig-import class-names cleaned-name-version)]
           (when-not (= old new)
-            (log/debug "file: " file " orig import:" orig-import " new import:" (prefix-occurrences orig-import package-names cleaned-name-version))
+            (log/debug "file: " file " orig import:" orig-import " new:" new)
             (spit file new))))
       (log/info "    prefixing imports: done"))))
 

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -167,47 +167,50 @@
 
 (deftest t-rewrite-java-imports
   (let [prefix "mrt010"]
-    (testing "fully-qualified import: package is prefixed in the import, class name in the body"
+    (testing "prefix-list import: package is prefixed in the import, class name in the body"
       (let [content     (str "(ns foo\n"
                              "  (:import [com.example Widget]))\n"
                              "(defn make [] (com.example.Widget/create))")
             orig-import "(:import [com.example Widget])"
-            class-names ["com.example.Widget"]
-            pkg-names   #{"com.example"}]
+            class-names ["com.example.Widget"]]
         (is (= (str "(ns foo\n"
                     "  (:import [mrt010.com.example Widget]))\n"
                     "(defn make [] (mrt010.com.example.Widget/create))")
-               (rewrite-java-imports content orig-import class-names pkg-names prefix)))))
+               (rewrite-java-imports content orig-import class-names prefix)))))
+
+    (testing "fully-qualified class import is prefixed when repackaged"
+      (is (= "(ns foo\n  (:import mrt010.com.example.Widget))"
+             (rewrite-java-imports "(ns foo\n  (:import com.example.Widget))"
+                                   "(:import com.example.Widget)"
+                                   ["com.example.Widget"] prefix))))
 
     (testing "a blank import fragment leaves the content untouched"
-      (is (= "(ns foo)" (rewrite-java-imports "(ns foo)" "" ["com.example.Widget"] #{"com.example"} prefix))))
+      (is (= "(ns foo)" (rewrite-java-imports "(ns foo)" "" ["com.example.Widget"] prefix))))
 
-    ;; The following two cases pin CURRENT (buggy) behavior so the structural
-    ;; import-rewrite fix has a regression net to flip. They are not the desired
-    ;; end state.
-    (testing "KNOWN BUG (#52): a class in a repackaged package but NOT itself repackaged is still prefixed"
-      ;; clj-tuple ships some `clojure.lang.*` class, so `clojure.lang` ends up in
-      ;; the package set; an unrelated import of core `clojure.lang.Var` should be
-      ;; left alone, but currently the whole package gets prefixed.
+    (testing "every class in a prefix-list is repackaged: the package is prefixed, no split"
+      (is (= "(ns foo\n  (:import [mrt010.com.example Widget Gadget]))"
+             (rewrite-java-imports "(ns foo\n  (:import [com.example Widget Gadget]))"
+                                   "(:import [com.example Widget Gadget])"
+                                   ["com.example.Widget" "com.example.Gadget"] prefix))))
+
+    (testing "#52: a class sharing a package with a repackaged one but not itself repackaged is left alone"
+      ;; clj-tuple ships some `clojure.lang.*` class, so `clojure.lang` shows up in
+      ;; the package set, but core `clojure.lang.Var`/`Compiler` must not be touched.
       (let [content     "(ns riddley.compiler\n  (:import [clojure.lang Var Compiler]))"
             orig-import "(:import [clojure.lang Var Compiler])"
-            class-names ["clojure.lang.Tuple"]   ;; the only actually-repackaged class
-            pkg-names   #{"clojure.lang"}]
-        (is (= "(ns riddley.compiler\n  (:import [mrt010.clojure.lang Var Compiler]))"
-               (rewrite-java-imports content orig-import class-names pkg-names prefix))
-            "currently over-prefixes; the fix should leave Var/Compiler untouched")))
+            class-names ["clojure.lang.Tuple"]]   ;; the only actually-repackaged class
+        (is (= content (rewrite-java-imports content orig-import class-names prefix))
+            "Var/Compiler are not repackaged, so the import is unchanged")))
 
-    (testing "KNOWN BUG (#33): a mixed import gets a single package prefix for classes that need different ones"
-      ;; In `[pkg Deftyped JavaClass]`, the deftype-generated class is prefixed by
-      ;; the namespace move (nested prefix) and the real java class by jarjar (flat
-      ;; prefix); the import form can only carry one package prefix today.
+    (testing "#33: a mixed import is split so each class gets the right package"
+      ;; `JavaClass` is a real java class (repackaged here); `Deftyped` is a
+      ;; deftype-generated class left under its original package for the namespace
+      ;; move to prefix separately.
       (let [content     "(ns user\n  (:import [com.acme.impl Deftyped JavaClass]))"
             orig-import "(:import [com.acme.impl Deftyped JavaClass])"
-            class-names ["com.acme.impl.JavaClass"]
-            pkg-names   #{"com.acme.impl"}]
-        (is (= "(ns user\n  (:import [mrt010.com.acme.impl Deftyped JavaClass]))"
-               (rewrite-java-imports content orig-import class-names pkg-names prefix))
-            "currently applies one package prefix to both; the fix should split the import")))))
+            class-names ["com.acme.impl.JavaClass"]]
+        (is (= "(ns user\n  (:import [com.acme.impl Deftyped] [mrt010.com.acme.impl JavaClass]))"
+               (rewrite-java-imports content orig-import class-names prefix)))))))
 
 (defn- temp-dir [prefix]
   (doto (File/createTempFile prefix "")


### PR DESCRIPTION
The Java `:import` rewriting prefixed by *package*: every class under a package that contained any repackaged class got the prefix. Two problems fall out of that:

- **#52**: a class that merely shares a package with a repackaged one gets wrongly prefixed (the report: core `clojure.lang.Var`/`Compiler` when clj-tuple ships its own `clojure.lang.*` class).
- **#33**: a single `(:import [pkg A B])` where `A` is a deftype-generated class (prefixed by the namespace move with the nested ns prefix) and `B` is a real Java class (prefixed flatly by jarjar) can't be expressed with one package prefix.

This parses the import form and rewrites it class-exactly: only classes actually in the repackaged set get the prefix, and a mixed prefix-list is split so the deftype class stays under its original package (for the ns move to handle) while the java class gets the jarjar prefix. The body rewriting was already class-exact, so only the import side changes.

Well covered by unit tests (including the #52 and #33 cases). The #33 deftype side leans on the existing namespace-move import handling; I verified the split at the unit level but didn't set up a full claypoole-style integration run, so I've referenced #33 rather than auto-closing it.

Fixes #52.

Stacked on #105, #106, #107 - merge those first; rebases cleanly onto master once they land. Builds directly on the #107 repackaging test harness.