### PR TITLE
Prefix java imports in top-level deps and the project's own sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
+- [fix [#54](https://github.com/benedekfazekas/mranderson/issues/54)] [fix [#92](https://github.com/benedekfazekas/mranderson/issues/92)] Rewrite Java `:import`s of inlined classes in top-level dependency namespaces and in the consuming project's own sources, which the per-dependency pass missed
 - [fix [#52](https://github.com/benedekfazekas/mranderson/issues/52)] Rewrite Java `:import`s by exact class rather than by package, so a class that merely shares a package with a repackaged one is left untouched
 - [[#33](https://github.com/benedekfazekas/mranderson/issues/33)] Split a mixed `(:import [pkg A B])` so a deftype-generated class and a real Java class in the same package each get the correct prefix
 - Java-class repackaging now operates on the configured `srcdeps` directory instead of a hardcoded `target/srcdeps`, so it works with `mranderson.core/inline-deps` and a custom `:target-path`

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -293,6 +293,33 @@
             (spit file new))))
       (log/info "    prefixing imports: done"))))
 
+(defn- import-excluded?
+  "True if `file`'s path (relative to `srcdeps`) falls under one of the
+  `prefix-exclusions` packages, which are left untouched when prefixing imports."
+  [prefix-exclusions srcdeps file]
+  (let [rel (u/srcdeps-relative srcdeps file)]
+    (boolean (some #(str/includes? rel (str (u/sym->file-name %) "/")) prefix-exclusions))))
+
+(defn- prefix-java-imports!
+  "Rewrites Java `:import`s of repackaged classes across every inlined source
+  file under `srcdeps` - both the dependencies and the consuming project. The
+  per-dependency pass misses top-level dependency namespaces (#54) and the
+  project's own files (#92); this final pass, run once all the dependency class
+  files are unpacked (so the full set of repackaged classes is known), covers
+  them. It is idempotent: `rewrite-java-imports` won't re-prefix an import that
+  was already rewritten by the per-dependency pass."
+  [pname pversion srcdeps prefix-exclusions]
+  (let [cleaned-name-version (u/clean-name-version pname pversion)
+        class-names          (map (partial u/class-file->fully-qualified-name srcdeps) (u/class-files srcdeps))]
+    (when (seq class-names)
+      (doseq [^File file (u/clojure-source-files [srcdeps])
+              :when      (not (import-excluded? prefix-exclusions srcdeps file))]
+        (let [old (slurp file)
+              new (rewrite-java-imports old (import-fragment old) class-names cleaned-name-version)]
+          (when-not (= old new)
+            (log/debug "    prefixing java imports in" (str file))
+            (spit file new)))))))
+
 (defn- update-artifact!
   [{:keys [pname pversion pprefix skip-repackage-java-classes srcdeps prefix-exclusions project-source-dirs expositions watermark]}
    {:keys [art-name-cleaned art-version clj-files clj-dirs dep]}
@@ -453,7 +480,7 @@
   - expositions: transient dependencies made available for the project source files in unresolved tree mode
   - watermark: meta flag to mark inlined dependencies"
 
-  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps] :as ctx} paths]
+  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps prefix-exclusions] :as ctx} paths]
   (let [source-dependencies         (filter u/source-dep? dependencies)
         resolved-deps-tree          (dr/resolve-source-deps repositories source-dependencies)
         overrides                   (or (and unresolved-tree overrides) {})
@@ -464,6 +491,10 @@
       (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))
     (when-not (or skip-repackage-java-classes (empty? (u/class-files srcdeps)))
       (let [jar-file (fs/file (fs/parent srcdeps) "class-deps.jar")]
+        ;; rewrite imports the per-dependency pass missed (top-level deps, the
+        ;; project's own files) while the class files are still in their original
+        ;; (unprefixed) locations, so their names are known
+        (prefix-java-imports! pname pversion srcdeps prefix-exclusions)
         (class-deps-jar! srcdeps jar-file)
         (u/apply-jarjar! pname pversion srcdeps jar-file)
         (replace-class-deps! srcdeps jar-file)))))

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -103,6 +103,41 @@
         (is (.exists (io/file working-directory name-version "difflib")))
         (is (not (.exists (io/file working-directory "difflib"))))))))
 
+(deftest t-project-java-imports-are-rewritten
+  ;; #92: the consuming project itself imports a class from an inlined dependency
+  ;; (difflib, pulled in via cljfmt); that import must be prefixed too.
+  (with-mranderson
+    [project {:dependencies '[^:inline-dep [cljfmt "0.7.0"]]
+              :files        [{:path    "mrt/main.clj"
+                              :content "(ns mrt.main\n  (:import [difflib DiffUtils]))"}]
+              :opts         {:unresolved-tree false}}]
+    (let [{:keys [working-directory]} project
+          name-version (util/clean-name-version "mranderson-test" "0.1.0-SNAPSHOT")
+          main         (io/file working-directory "mrt" "main.clj")]
+      (is (string/includes? (slurp main) (str "[" name-version ".difflib DiffUtils]"))
+          "the project's import of an inlined java class is prefixed")
+      (is (not (string/includes? (slurp main) "[difflib DiffUtils]"))
+          "the original, unprefixed import is gone"))))
+
+(deftest t-top-level-namespace-java-imports-are-rewritten
+  ;; #54: clj-tuple has a top-level `clj-tuple` namespace that imports the
+  ;; `clojure.lang.*` classes it generates; the per-dependency pass skips
+  ;; top-level namespaces, so its imports weren't being prefixed.
+  (with-mranderson
+    [project {:dependencies '[^:inline-dep [clj-tuple "0.2.2"]]
+              :files        []
+              :opts         {:unresolved-tree false}}]
+    (let [{:keys [working-directory]} project
+          name-version (util/clean-name-version "mranderson-test" "0.1.0-SNAPSHOT")
+          tuple-file   (->> (file-seq working-directory)
+                            (filter #(= "clj_tuple.clj" (.getName ^File %)))
+                            first)]
+      (is (some? tuple-file) "clj_tuple.clj should have been inlined")
+      (is (string/includes? (slurp tuple-file) (str name-version ".clojure.lang"))
+          "the top-level namespace's import of a repackaged class is prefixed")
+      (is (not (re-find #"\[clojure\.lang " (slurp tuple-file)))
+          "the original, unprefixed clojure.lang import is gone"))))
+
 (deftest t-copy-source-files
   (testing "Can merge files across overlapping dirs"
     (let [dir-a "test-resources/a"


### PR DESCRIPTION
The per-dependency import pass only rewrites an artifact's own non-top-level files, so imports of inlined Java classes were missed in two places:

- **#54**: a dependency's *top-level* namespace (the canonical repro is clj-tuple, whose top-level `clj-tuple` ns imports the `clojure.lang.*` classes it generates) - top-level namespaces produce a blank prefix that `possible-prefixes` drops, so they were never visited.
- **#92**: the *consuming project's* own sources, which import a class from an inlined dependency.

This adds a final pass over every inlined source file under `srcdeps`, run once all the dependency class files are unpacked so the full repackaged-class set is known. It honours `:prefix-exclusions` and is idempotent (`rewrite-java-imports` won't re-prefix an already-rewritten import), so it cleanly supplements the per-dependency pass rather than fighting it. Both fixes have tests that fail without the new pass.

Fixes #54. Fixes #92.

Stacked on #105/#106/#107/#108 - builds on the class-exact rewriting and the repackaging test harness from those.