### PR TITLE
Handle (load ...) resource paths when relocating namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes
 
+- [fix [#61](https://github.com/benedekfazekas/mranderson/issues/61)] Repoint `(load "…")` resource paths when a namespace is relocated, so libraries that `load` companion files (e.g. `tools.deps.alpha`) inline correctly
 - [fix [#73](https://github.com/benedekfazekas/mranderson/issues/73)] Munge the package of fully-qualified class/record references to Java style so a dash in the prefix doesn't produce broken references
 - [fix [#64](https://github.com/benedekfazekas/mranderson/issues/64)] Strip non-alphanumeric characters (e.g. a `/` in a `n/a` version) from the generated prefix so they don't break imports
 - [fix [#54](https://github.com/benedekfazekas/mranderson/issues/54)] [fix [#92](https://github.com/benedekfazekas/mranderson/issues/92)] Rewrite Java `:import`s of inlined classes in top-level dependency namespaces and in the consuming project's own sources, which the per-dependency pass missed

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -70,6 +70,15 @@
 (defn- java-package [sym]
   (str/replace (name sym) "-" "_"))
 
+(defn- load-param
+  "Renders `sym` as the resource path used by `(load \"…\")`: dots become
+  slashes and dashes underscores, e.g. `clojure.tools.deps.alpha` ->
+  `clojure/tools/deps/alpha`."
+  [sym]
+  (-> (name sym)
+      (str/replace "." "/")
+      (str/replace "-" "_")))
+
 (defn- java-style-prefix?
   [old-sym node]
   (when-not (#{:uneval} (z/tag node))
@@ -259,7 +268,9 @@
         old-pkg-prefix  (java-package old-sym)
         new-pkg-prefix  (java-package new-sym)
         old-type-prefix (str "^" (java-package old-sym))
-        new-type-prefix (str "^" (java-package new-sym))]
+        new-type-prefix (str "^" (java-package new-sym))
+        old-load-param  (load-param old-sym)
+        new-load-param  (load-param new-sym)]
     (cond
 
       (= match old-ns-ref)
@@ -281,6 +292,10 @@
           (java-package replaced)
           replaced))
 
+      ;; a `(load "…")` resource path, in slash/underscore form. See #61.
+      (str/starts-with? match old-load-param)
+      (str/replace match old-load-param new-load-param)
+
       :default
       match)))
 
@@ -291,7 +306,12 @@
   #"\"?[a-zA-Z0-9$%*+=?!<>^_-]['.a-zA-Z0-9$%*+=?!<>_-]*")
 
 (defn- replace-in-source [source-sans-ns old-sym new-sym]
-  (str/replace source-sans-ns symbol-regex (partial source-replacement old-sym new-sym)))
+  ;; `symbol-regex` never matches a `(load "…")` resource path (it stops at `/`),
+  ;; so try the slash/underscore form of the namespace first. See #61.
+  (let [regex (re-pattern (str (java.util.regex.Pattern/quote (load-param old-sym))
+                               "|"
+                               (.pattern ^java.util.regex.Pattern symbol-regex)))]
+    (str/replace source-sans-ns regex (partial source-replacement old-sym new-sym))))
 
 (defn- after-platform-marker? [platform node]
   (when-not (#{:uneval} (z/tag node))

--- a/test-resources/load-statement-example.txt
+++ b/test-resources/load-statement-example.txt
@@ -1,0 +1,16 @@
+(ns
+  ^{:author "Alex Taggart"
+    :doc
+    "Support for testing whether logging calls are made.
+
+  Usage example:
+    (require '[clojure.tools.logging :as log]
+             '[clojure.tools.logging.test :refer [logged? with-log])
+
+    (with-log
+      (log/info \"Hello World!\")
+      (log/error (Exception. \"Did a thing\") \"Error: oops\")
+      (logged? 'user :info #\"Hello\"))"}
+  foo.bar.alpha)
+
+(load "/foo/bar/alpha/extensions/maven")

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -304,6 +304,29 @@
       (t/is (= (slurp file-moved-metamap2) expected-moved-metamap2-watermark)))))
 
 
+(t/deftest move-ns-load-statement-test
+  ;; `(load "…")` embeds a resource PATH (slashes), which the symbol-based body
+  ;; rewriting never sees; it must be repointed when the namespace moves (#61).
+  ;; The namespace also carries a docstring full of example Clojure code and
+  ;; escaped quotes, to confirm that doesn't trip up ns-form parsing.
+  (let [temp-dir (create-temp-dir! "mranderson-load")
+        src-dir  (io/file temp-dir "src")
+        _        (create-source-file! (io/file src-dir "foo" "bar" "alpha.clj")
+                                      (slurp "test-resources/load-statement-example.txt"))
+        moved    (io/file src-dir "moved" "foo" "bar" "alpha.clj")]
+    (sut/move-ns 'foo.bar.alpha 'moved.foo.bar.alpha src-dir ".clj" [src-dir] nil)
+    (t/is (.exists moved)
+          "the file is moved to the new namespace location")
+    (let [out (slurp moved)]
+      (t/is (.contains out "moved.foo.bar.alpha")
+            "the namespace is renamed")
+      (t/is (.contains out "(load \"/moved/foo/bar/alpha/extensions/maven\")")
+            "the load path is repointed to the new location")
+      (t/is (not (.contains out "\"/foo/bar/alpha/extensions"))
+            "the original load path is gone")
+      (t/is (.contains out "Alex Taggart")
+            "the docstring metadata is preserved through the move"))))
+
 (defn- s-rename-ns
   "A litle helper for rename-ns-test"
   [s old-ns-name new-ns-name add-meta-kw]
@@ -373,4 +396,9 @@
 
       ;; the bare namespace itself keeps the dashes
       "cider.nrepl.inlined-deps.instaparse.gll"
-      "instaparse.gll")))
+      "instaparse.gll"
+
+      ;; a (load "…") resource path is repointed in slash/underscore form (#61);
+      ;; the dash in the prefix becomes an underscore, like a package path
+      "(load \"/cider/nrepl/inlined_deps/instaparse/gll/extra\")"
+      "(load \"/instaparse/gll/extra\")")))


### PR DESCRIPTION
A `(load "/foo/bar")` form embeds a *resource path* (slashes and underscores), not a namespace symbol. The body rewriter works token by token and its symbol regex stops at `/`, so it never saw these paths - after inlining, a `load` still pointed at the dependency's original, now-relocated location. This bites libraries that split a namespace across `load`ed companion files, like `tools.deps.alpha`.

The fix matches the namespace's load-path form (dots to slashes, dashes to underscores) in the body pass and repoints it. The companion files loaded this way usually have no `ns` of their own, so the existing "clj file without ns" relocation already moves them to exactly the spot the repointed path expects. This is the maintainer's own `handle-load-stmt` sketch, re-applied on top of the current class-reference handling.

The test deliberately uses a namespace whose docstring is full of example Clojure code and escaped quotes - the reader hiccup that was reported alongside this issue turns out to be a non-problem on current master, and this pins that. Both tests fail without the fix.

Fixes #61.

Stacked on #104 (they both touch `source-replacement`); rebases cleanly onto master once that lands.