### PR TITLE
Add safety-net tests for previously untested areas

### DIFF
--- a/test/leiningen/inline_deps_test.clj
+++ b/test/leiningen/inline_deps_test.clj
@@ -3,6 +3,8 @@
             [clojure.test :as t]))
 
 (def ^:private aot-configured? #'inline-deps/aot-configured?)
+(def ^:private lookup-opt #'inline-deps/lookup-opt)
+(def ^:private lein-project->ctx #'inline-deps/lein-project->ctx)
 
 (t/deftest aot-configured?-test
   (t/are [expected aot] (= expected (boolean (aot-configured? aot)))
@@ -12,3 +14,36 @@
     true  :all
     true  '[my.ns.one my.ns.two]
     true  '[my.ns.one]))
+
+(t/deftest lookup-opt-test
+  (t/testing "a CLI option wins over the project map, which wins over the default"
+    (t/is (= "from-cli"
+             (lookup-opt :project-prefix '(:project-prefix "from-cli") {:project-prefix "from-proj"} "default")))
+    (t/is (= "from-proj"
+             (lookup-opt :project-prefix '() {:project-prefix "from-proj"} "default")))
+    (t/is (= "default"
+             (lookup-opt :project-prefix '() {} "default")))))
+
+(t/deftest lein-project->ctx-test
+  (let [project {:root        "/p"
+                 :target-path "/p/target"
+                 :name        "my-proj"
+                 :version     "1.2.3"
+                 :mranderson  {:project-prefix           "proj.inlined"
+                               :unresolved-tree          false
+                               :skip-javaclass-repackage true}}
+        ;; a CLI flag that should override the project map's :unresolved-tree
+        ctx     (lein-project->ctx project [":unresolved-tree" "true"])]
+    (t/testing "project name/version pass through"
+      (t/is (= "my-proj" (:pname ctx)))
+      (t/is (= "1.2.3" (:pversion ctx))))
+    (t/testing "prefix comes from the :mranderson config"
+      (t/is (= "proj.inlined" (:pprefix ctx))))
+    (t/testing "a CLI option overrides the project map"
+      (t/is (true? (:unresolved-tree ctx))))
+    (t/testing "the lein option name :skip-javaclass-repackage maps to :skip-repackage-java-classes"
+      (t/is (true? (:skip-repackage-java-classes ctx))))
+    (t/testing "srcdeps is computed relative to the target path"
+      (t/is (= "target/srcdeps" (:srcdeps ctx))))
+    (t/testing "watermark defaults to :mranderson/inlined"
+      (t/is (= :mranderson/inlined (:watermark ctx))))))

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -34,6 +34,40 @@
 
 ;; ## Tests
 
+(deftest t-unresolved-tree
+  ;; Unresolved-tree mode nests each transitive dependency under its parent
+  ;; (fipp under puget), unlike the flat resolved-tree layout. This whole mode
+  ;; was previously untested end to end.
+  (with-mranderson
+    [project {:dependencies '[^:inline-dep [mvxcvi/puget "1.0.2"]]
+              :files        [{:path    "mrt/main.clj"
+                              :content "(ns mrt.main (:require [puget.printer :as p]))"}]
+              :opts         {:skip-repackage-java-classes true
+                             :unresolved-tree             true}}]
+    (let [{:keys [working-directory prefix ns-prefix]} project
+          puget-dir      (io/file working-directory prefix "puget" "v1v0v2")
+          puget-printer  (io/file puget-dir "puget" "printer.clj")
+          nested-fipp    (io/file puget-dir "fipp" "v0v6v10" "fipp" "ednize.clj")
+          nested-fipp-ns (str ns-prefix ".puget.v1v0v2.fipp.v0v6v10.fipp")]
+
+      (testing "the dependency is shadowed under the project prefix"
+        (is (.exists puget-printer))
+        (is (string/includes? (slurp puget-printer)
+                              (str ns-prefix ".puget.v1v0v2.puget.printer"))))
+
+      (testing "a transitive dep is nested under its parent (the unresolved-tree hallmark)"
+        (is (.exists nested-fipp))
+        (is (string/includes? (slurp nested-fipp) (str nested-fipp-ns ".ednize"))))
+
+      (testing "cross-dependency references resolve to the nested prefix"
+        (is (some #(string/includes? (slurp %) nested-fipp-ns)
+                  (filter #(.endsWith (.getName ^File %) ".clj") (file-seq puget-dir)))
+            "puget should reference fipp via its nested shadow prefix"))
+
+      (testing "the project's own require is rewritten to the shadowed dependency"
+        (is (string/includes? (slurp (io/file working-directory "mrt" "main.clj"))
+                              (str ns-prefix ".puget.v1v0v2.puget.printer")))))))
+
 (deftest t-resolved-tree-and-skip-java-repackage-classes
   (with-mranderson
     [project {:dependencies dependencies

--- a/test/mranderson/dependency_tree_test.clj
+++ b/test/mranderson/dependency_tree_test.clj
@@ -1,0 +1,63 @@
+(ns mranderson.dependency-tree-test
+  "Pure (network-free) tests for the dependency-tree walking and ordering
+  machinery that drives both resolved-tree and unresolved-tree processing."
+  (:require [clojure.test :as t]
+            [mranderson.dependency.tree :as tree]))
+
+(t/deftest walk-deps-test
+  (t/testing "visits every node depth-first with an incrementing level"
+    (let [visited (atom [])]
+      (tree/walk-deps '{[a "1"] {[b "1"] nil
+                                 [c "1"] {[d "1"] nil}}}
+                      (fn [dep level] (swap! visited conj [(first dep) level])))
+      (t/is (= '[[a 0] [b 1] [c 1] [d 2]] @visited)))))
+
+(t/deftest evict-subtrees-test
+  (t/testing "removes the named roots (any version) and their subtrees, at any depth"
+    (t/is (= '{[a "1"] {[b "1"] nil}}
+             (tree/evict-subtrees '{[a "1"] {[clj "1.8.0"] nil
+                                             [b "1"]       {[clj "1.5.1"] nil}}}
+                                  '#{clj})))))
+
+(t/deftest topological-order-test
+  (t/testing "assigns a deterministic rank per dependency, shallower (depended-upon) first"
+    ;; a linear chain: a has b as a dep, b has c
+    (t/is (= '{a 0 b 1 c 2}
+             (tree/topological-order '{[a "1"] {[b "1"] {[c "1"] nil}}})))))
+
+(t/deftest walk-dep-tree-test
+  (t/testing "depth-first: pre-fn on the way down, post-fn on the way up, with paths threaded down"
+    (let [events (atom [])
+          pre    (fn [_ctx paths dep]
+                   (swap! events conj [:pre (first dep) paths])
+                   ;; pre-result, and the paths handed to the children
+                   [(first dep) (conj paths (first dep))])
+          post   (fn [_ctx pre-result _paths]
+                   (swap! events conj [:post pre-result]))]
+      (tree/walk-dep-tree '{[a "1"] {[b "1"] nil}} pre post [] nil)
+      ;; the exact sequence pins the depth-first pre/post order, including the
+      ;; fact that a node's post-fn runs only after its whole subtree
+      (t/is (= '[[:pre a []]
+                 [:pre b [a]]
+                 [:post b]
+                 [:post a]]
+               @events)))))
+
+(t/deftest walk-ordered-deps-test
+  (t/testing "pre-fn in order, post-fn in reverse, accumulating parent-clj-dirs"
+    (let [pre-order  (atom [])
+          post-order (atom [])
+          post-paths (atom nil)
+          pre        (fn [_ctx _paths dep]
+                       (swap! pre-order conj (first dep))
+                       [(first dep) {:parent-clj-dirs [(first dep)]}])
+          post       (fn [_ctx pre-result paths]
+                       (swap! post-order conj pre-result)
+                       (reset! post-paths (:parent-clj-dirs paths)))]
+      ;; an (ordered) flat list of deps, as produced for resolved-tree mode
+      (tree/walk-ordered-deps (array-map '[a "1"] nil '[b "1"] nil '[c "1"] nil)
+                              pre post {:parent-clj-dirs []} nil)
+      (t/is (= '[a b c] @pre-order) "pre-fn runs in order")
+      (t/is (= '[c b a] @post-order) "post-fn runs in reverse order")
+      (t/is (= '[a b c] @post-paths)
+            "post-fn sees every node's parent-clj-dirs accumulated"))))


### PR DESCRIPTION
Part of the post-0.6.0 modernization (audit batch 1). Locks down the areas flagged as unguarded before we start refactoring them:

- **Unresolved-tree mode** was entirely untested end to end. `t-unresolved-tree` inlines puget with `:unresolved-tree true` and asserts the nesting hallmark (the transitive fipp ends up *under* puget), cross-dependency references resolving to the nested prefix, and the project's own require being rewritten.
- **`dependency.tree` ordering/walking** had no direct assertions. Added pure, network-free unit tests for `walk-deps`, `evict-subtrees`, `topological-order`, `walk-dep-tree`, and `walk-ordered-deps`.
- **The Leiningen plugin's option plumbing** was near-zero. Added tests for `lookup-opt` precedence (CLI > project map > default) and `lein-project->ctx`, pinning the `:skip-javaclass-repackage` -> `:skip-repackage-java-classes` mapping.

Tests only, no behaviour change. Full suite: 35 tests / 170 assertions, green.