### PR TITLE
Harden CI: hard-fail the inline pipeline, add a Clojure matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,16 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17]
-
+        jdk: [8, 11, 17, 21]
+        clojure: ['1.10', '1.11', '1.12']
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v4
@@ -38,28 +36,105 @@ jobs:
           key: m2-${{ hashFiles('project.clj') }}
           restore-keys: m2-
 
-      - name: Install dependencies
-        run: lein deps
+      - name: Run tests (Clojure ${{ matrix.clojure }})
+        run: lein with-profile +${{ matrix.clojure }} test
 
-      - name: Run tests
-        run: lein test
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: latest
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('project.clj') }}
+          restore-keys: m2-
+
+      - name: Eastwood
+        run: lein with-profile +eastwood eastwood
 
       - name: Shellcheck
         run: shellcheck scripts/*.sh
 
-      - name: Integration tests
-        continue-on-error: true
-        run: scripts/integration_test.sh
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Lint
-        run: lein with-profile +eastwood eastwood
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: latest
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('project.clj') }}
+          restore-keys: m2-
 
       - name: Coverage
         run: lein kaocha-coverage --codecov
 
       - name: Upload coverage
-        if: matrix.jdk == 11
         uses: codecov/codecov-action@v5
         with:
           files: target/coverage/codecov.json
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: latest
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('project.clj') }}
+          restore-keys: m2-
+
+      # MrAnderson inlining its own (pinned) dependencies is deterministic, so a
+      # failure here is a real regression in the core pipeline and must fail CI.
+      - name: Build inlined MrAnderson
+        run: make install
+
+      # cider-nrepl/refactor-nrepl track moving upstream targets, so their builds
+      # are informative but allowed to fail without turning the whole run red.
+      - name: Downstream integration (cider-nrepl, refactor-nrepl)
+        continue-on-error: true
+        run: scripts/downstream_test.sh

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,10 @@
                  [org.pantsbuild/jarjar "1.7.2"]]
   :mranderson {:project-prefix "mranderson.inlined"}
   :profiles {:dev {:dependencies [[leiningen-core "2.12.0"]]}
+             ;; Clojure version profiles, exercised by the CI matrix.
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}
              :eastwood {:plugins [[jonase/eastwood "1.4.3"]]
                         :eastwood {:exclude-linters [:no-ns-form-found]}}
              :mranderson-plugin {:plugins [[thomasa/mranderson ~project-version]]}

--- a/scripts/downstream_test.sh
+++ b/scripts/downstream_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Build cider-nrepl and refactor-nrepl against the locally installed mranderson
+# and run their mrandersonized test suites. Assumes `make install` has already
+# installed mranderson to the local maven repo (CI runs that as a separate,
+# hard-failing step; `make integration-test` does it via integration_test.sh).
+
+git submodule update --init --recursive
+
+# cider-nrepl observes CI, which triggers :pedantic?, which is irrelevant here:
+unset CI
+
+cd test-resources/cider-nrepl
+lein clean
+lein with-profile -user,-dev inline-deps
+lein with-profile -user,-dev,+1.10,+test,+plugin.mranderson/config test
+
+cd ../refactor-nrepl
+lein clean
+make test

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -2,20 +2,11 @@
 set -Eeuxo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-# An integration test that exercises that cider-nrepl and refactor-nrepl can successfully use mranderson @ latest.
-# For that, we both build those projects with mranderson in them, and run their mrandersonized test suites.
+# Full integration test: build and install mranderson, then exercise it through
+# cider-nrepl and refactor-nrepl. This is the all-in-one entry point for local
+# use (`make integration-test`). CI instead runs the two phases as separate
+# steps so the deterministic install can fail hard while the downstream builds
+# (which track moving upstream targets) stay soft.
 
 make install
-git submodule update --init --recursive
-
-# cider-nrepl observes CI, which triggers :pedantic?, which is irrelevant here:
-unset CI
-
-cd test-resources/cider-nrepl
-lein clean
-lein with-profile -user,-dev inline-deps
-lein with-profile -user,-dev,+1.10,+test,+plugin.mranderson/config test
-
-cd ../refactor-nrepl
-lein clean
-make test
+scripts/downstream_test.sh


### PR DESCRIPTION
Audit batch 1, the CI half (the tests half is #111).

The hole the audit found: the only end-to-end test of mranderson's actual inlining pipeline (`make install`, which builds mranderson with its own dependencies inlined) ran inside a `continue-on-error` integration step. So the product's core function could break and CI would still go green, while coverage - the only other signal - is informational-only.

This splits the integration step in two:
- **Build inlined MrAnderson** (`make install`) - deterministic (it inlines mranderson's own pinned deps), so it now **hard-fails**.
- **Downstream integration** (cider-nrepl/refactor-nrepl, in a new `scripts/downstream_test.sh`) - these track moving upstream targets, so they stay `continue-on-error`.

It also addresses the single-Clojure gap: the suite only ever ran on 1.10.3. Added a **Clojure 1.10/1.11/1.12** matrix (new version profiles in project.clj, verified to resolve) crossed with **JDK 8/11/17/21**, and split eastwood/coverage/integration into their own jobs so they run once instead of on every matrix cell. Per-job timeouts added.

`make integration-test` still runs the whole thing locally via the slimmed `integration_test.sh`. Shellcheck passes on both scripts; YAML validated.