### PR TITLE
Remove dead code and tidy a few idioms

### DIFF
--- a/java-src/mranderson/util/JjMainProcessor.java
+++ b/java-src/mranderson/util/JjMainProcessor.java
@@ -24,7 +24,6 @@ import org.pantsbuild.jarjar.PatternElement;
 import org.pantsbuild.jarjar.Rule;
 import org.pantsbuild.jarjar.util.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -32,9 +31,8 @@ public class JjMainProcessor implements JarProcessor
 {
     private final boolean verbose;
     private final JarProcessorChain chain;
-    private final Map<String, String> renames = new HashMap<String, String>();
 
-    public JjMainProcessor(List<PatternElement> patterns, boolean verbose, boolean skipManifest) {
+    public JjMainProcessor(List<PatternElement> patterns, boolean verbose) {
         this.verbose = verbose;
         List<Rule> ruleList = new ArrayList<Rule>();
         for (PatternElement pattern : patterns) {
@@ -48,20 +46,6 @@ public class JjMainProcessor implements JarProcessor
         List<JarProcessor> processors = new ArrayList<JarProcessor>();
         processors.add(new JarTransformerChain(new RemappingClassTransformer[]{ new RemappingClassTransformer(pr) }));
         chain = new JarProcessorChain(processors.toArray(new JarProcessor[processors.size()]));
-    }
-
-    public void strip(File file) throws IOException {
-        return;
-    }
-
-    /**
-     * Returns the <code>.class</code> files to delete. As well the root-parameter as the rename ones
-     * are taken in consideration, so that the concerned files are not listed in the result.
-     *
-     * @return the paths of the files in the jar-archive, including the <code>.class</code> suffix
-     */
-    private Set<String> getExcludes() {
-        return new HashSet<String>();
     }
 
     /**

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -57,8 +57,7 @@
        (map cljfile->prefix)
        (remove #(str/blank? %))
        (remove #(= "clojure.core" %))
-       frequencies
-       keys
+       distinct
        (map #(str/replace % "_" "-"))))
 
 (defn- replacement-prefix [pprefix src-path art-name art-version underscorize?]
@@ -102,7 +101,7 @@
                     (not (re-matches #"\s" (-> ns-decl-fragment first str)))
                     (count clj-source)
 
-                    :default (recur (rest ns-decl-fragment) (inc index-of-open-bracket)))) clj-source))))
+                    :else (recur (rest ns-decl-fragment) (inc index-of-open-bracket)))) clj-source))))
 
 (defn- import-fragment [clj-source]
   (let [import-fragment-left (import-fragment-left clj-source)
@@ -124,7 +123,7 @@
                                    (= \) (nth import-fragment-left index))
                                    (inc open-close)
 
-                                   :default open-close)))))))
+                                   :else open-close)))))))
 
 (defn- retrieve-import [file-prefix file]
   (let [cont (slurp (fs/file file-prefix file))

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -125,7 +125,7 @@
     (cond
       (symbol? old-node) (symbol new-node)
 
-      :default new-node)))
+      :else new-node)))
 
 (defn- ns-decl? [node]
   (when-not (#{:uneval} (z/tag node))
@@ -156,7 +156,7 @@
     (cond
       (symbol? old-node) (symbol new-node)
 
-      :default new-node)))
+      :else new-node)))
 
 (defn- replace-in-import* [import-loc old-sym new-sym]
   (loop [loc import-loc]
@@ -296,7 +296,7 @@
       (str/starts-with? match old-load-param)
       (str/replace match old-load-param new-load-param)
 
-      :default
+      :else
       match)))
 
 (def ^:private symbol-regex

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -1,6 +1,5 @@
 (ns mranderson.util
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
             [clojure.set :as s]
@@ -119,19 +118,10 @@
   (let [java-dirs (java-class-dirs srcdeps)
         name-version (clean-name-version pname pversion)
         rules (map (partial create-rule name-version) java-dirs)
-        processor (JjMainProcessor. rules false false)
+        processor (JjMainProcessor. rules false)
         jar-file (io/file jar-file)]
     (log/info (format "prefixing %s in %s with %s" java-dirs jar-file name-version))
     (StandaloneJarProcessor/run jar-file jar-file processor)))
-
-(defn mranderson-version []
-  (let [v (-> (io/resource "mranderson/project.clj")
-              slurp
-              edn/read-string
-              (nth 2))]
-    (assert (string? v)
-            (str "Something went wrong, version is not a string: " v))
-    v))
 
 (defn file->extension
   [file]


### PR DESCRIPTION
Audit batch 3 - low-risk cleanup, no behaviour change.

- Drop the unused `mranderson.util/mranderson-version` (no callers anywhere) and the `clojure.edn` require it was the only user of.
- Strip dead members from `JjMainProcessor`: the no-op `strip` method, the unused private `getExcludes`, the dead `renames` field, and the never-read `skipManifest` constructor argument (now a 2-arg constructor; its single caller updated).
- Use `:else` instead of `:default` as the `cond` catch-all (5 forms).
- `possible-prefixes` now dedupes with `distinct` instead of `frequencies` + `keys`.

Eastwood clean, full suite green, Java recompiles.