### PR TITLE
Rewrite namespace references in a single global pass (resolved-tree)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- Speed up inlining by rewriting namespace references in a single pass: in resolved-tree mode every source file is now parsed once instead of once per dependency whose scope overlapped it (it was effectively O(files x namespaces))
+
 ## 0.6.0
 
 ### Bug fixes

--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,10 @@
              :kaocha {:eval-in :sub-process
                       :dependencies [[lambdaisland/kaocha "1.91.1392"]
                                      [lambdaisland/kaocha-cloverage "1.1.89"]]}}
-  :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]
-            "kaocha-watch" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--watch"]
-            "kaocha-coverage" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--plugin" "cloverage"]})
+  ;; the perf benchmark (mranderson.benchmark) is excluded from normal runs; run
+  ;; it explicitly with `lein test :benchmark`.
+  :test-selectors {:default   (complement :benchmark)
+                   :benchmark :benchmark}
+  :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--skip-meta" ":benchmark"]
+            "kaocha-watch" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--watch" "--skip-meta" ":benchmark"]
+            "kaocha-coverage" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner" "--plugin" "cloverage" "--skip-meta" ":benchmark"]})

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -256,46 +256,59 @@
             (spit file new)))))))
 
 (defn- update-artifact!
-  [{:keys [pprefix skip-repackage-java-classes srcdeps project-source-dirs expositions watermark]}
+  "Moves an artifact's namespaces and collects the resulting renames.
+
+  In resolved-tree mode the renames are returned and applied later in a single
+  global pass (the rename map is 1:1, so no per-artifact dir scoping is needed).
+  In unresolved-tree mode the same namespace can be copied to many nested
+  locations with location-dependent prefixes, so references are rewritten within
+  this artifact's subtree right here, and `nil` is returned.
+
+  Java `:import`s are handled separately by the global `prefix-java-imports!`
+  pass once all class files are unpacked."
+  [{:keys [pprefix srcdeps project-source-dirs expositions watermark unresolved-tree]}
    {:keys [art-name-cleaned art-version clj-files clj-dirs dep]}
    {:keys [src-path parent-clj-dirs branch]}]
-  (let [repl-prefix      (replacement-prefix pprefix src-path art-name-cleaned art-version nil)
-        expose?          (first (filter (partial t/path-pred branch dep) expositions))
-        all-deps-dirs    (->> (concat
-                               [src-path]
-                               (map fs/file clj-dirs)
-                               parent-clj-dirs)
-                              vec
-                              (mapv str)
-                              u/normalize-dirs
-                              (mapv fs/file))]
+  (let [repl-prefix (replacement-prefix pprefix src-path art-name-cleaned art-version nil)
+        expose?     (first (filter (partial t/path-pred branch dep) expositions))]
     (log/info (format "  munge source files of %s artifact on branch %s exposed %s." art-name-cleaned branch (boolean expose?)))
-    (log/debug "    proj-source-dirs" project-source-dirs " clj files" clj-files "clj dirs" clj-dirs " path to dep" src-path "parent-clj-dirs: " parent-clj-dirs)
     (log/debug "    modified namespace prefix: " repl-prefix)
-    (log/debug "    src path: " src-path)
-    (log/debug "    parent clj dirs: " (str/join ":" parent-clj-dirs))
-    (log/debug "    all dirs: " all-deps-dirs)
-    (log/debug (format "    modified dependency name: %s modified version string: %s" art-name-cleaned art-version))
-    ;; Java `:import`s are rewritten in a single global pass (`prefix-java-imports!`)
-    ;; once all class files are unpacked; nothing to do per-artifact here.
-    (doseq [clj-file clj-files
-            :when (.exists (fs/file srcdeps clj-file))];; some cljc file might have been moved with their platform specific file
-      (if-let [old-ns (some->> clj-file (fs/file srcdeps) read-file-ns-decl second)]
-        (let [new-ns (replacement repl-prefix old-ns nil)]
-          (log/debug "    new ns:" new-ns)
-          (move/move-ns old-ns new-ns srcdeps (u/file->extension (str clj-file)) all-deps-dirs watermark)
+    ;; Move every namespace's file(s) and collect the renames; handle the rare
+    ;; no-`ns` files inline.
+    (let [renames (reduce
+                   (fn [renames clj-file]
+                     (if-not (.exists (fs/file srcdeps clj-file)) ; some cljc may have moved with its platform file
+                       renames
+                       (if-let [old-ns (some->> clj-file (fs/file srcdeps) read-file-ns-decl second)]
+                         (let [new-ns (replacement repl-prefix old-ns nil)
+                               ext    (u/file->extension (str clj-file))]
+                           (log/debug "    new ns:" new-ns)
+                           (move/move-ns-files! old-ns new-ns srcdeps ext)
+                           (conj renames {:old-sym old-ns :new-sym new-ns :extension ext :watermark watermark}))
+                         ;; a clj file without ns
+                         (do
+                           (when-not (= "project.clj" clj-file)
+                             (let [old-path (fs/file srcdeps clj-file)
+                                   new-path (str (u/sym->file-name pprefix) "/" art-name-cleaned "/" art-version "/" clj-file)]
+                               (fs/copy+ old-path (fs/file srcdeps new-path))
+                               ;; replace occurrences of file path references
+                               (doseq [file (u/clojure-source-files [srcdeps])]
+                                 (update-path-in-file file clj-file new-path))
+                               ;; remove old file
+                               (fs/delete old-path)))
+                           renames))))
+                   []
+                   clj-files)]
+      (if-not unresolved-tree
+        renames
+        (let [all-deps-dirs (->> (concat [src-path] (map fs/file clj-dirs) parent-clj-dirs)
+                                 vec (mapv str) u/normalize-dirs (mapv fs/file))]
+          (move/replace-ns-symbols-in-source-files renames all-deps-dirs)
           (when (or (str/ends-with? src-path (u/sym->file-name pprefix)) expose?)
-            (move/replace-ns-symbol-in-source-files old-ns new-ns (u/file->extension (str clj-file)) project-source-dirs nil)))
-        ;; a clj file without ns
-        (when-not (= "project.clj" clj-file)
-          (let [old-path (fs/file srcdeps clj-file)
-                new-path (str (u/sym->file-name pprefix) "/" art-name-cleaned "/" art-version "/" clj-file)]
-            (fs/copy+ old-path (fs/file srcdeps new-path))
-            ;; replace occurrences of file path references
-            (doseq [file (u/clojure-source-files [srcdeps])]
-              (update-path-in-file file clj-file new-path))
-            ;; remove old file
-            (fs/delete old-path)))))))
+            (move/replace-ns-symbols-in-source-files
+             (mapv #(assoc % :watermark nil) renames)
+             project-source-dirs))
+          nil)))))
 
 (defn- remove-invalid-duplicates!
   "See issue #44. Some artifacts package duplicate files in weird locations
@@ -388,12 +401,12 @@
                                         (into (sorted-map-by topo-comparator)))]
     (log/info "in RESOLVED-TREE mode, working on a resolved dependency tree")
     (t/walk-deps resolved-deps print-dep)
-    (t/walk-ordered-deps
-     ordered-resolved-deps
-     unzip-artifact!
-     update-artifact!
-     paths
-     ctx)))
+    ;; Each artifact moves its files and returns its renames; rewrite every
+    ;; reference across all sources in a single pass, so each file is parsed once
+    ;; rather than once per artifact whose dir scope overlaps it.
+    (let [renames (->> (t/walk-ordered-deps ordered-resolved-deps unzip-artifact! update-artifact! paths ctx)
+                       (apply concat))]
+      (move/replace-ns-symbols-in-source-files renames [(:srcdeps ctx)]))))
 
 (defn mranderson
   "Inline and shadow dependencies so they can not interfere with other libraries' dependencies.

--- a/src/mranderson/dependency/tree.clj
+++ b/src/mranderson/dependency/tree.clj
@@ -74,13 +74,14 @@
   "Walks a flat list of dependencies.
 
   Applies `pre-fn` on all the dependencies and collects the `pre-fn` returned contextual values and paths.
-  Runs `post-fn` on all the dependencies in a reverse order using the `pre-fn` results and paths."
+  Runs `post-fn` on all the dependencies in a reverse order using the `pre-fn` results and paths, and
+  returns a vector of the `post-fn` results in that order."
   [deps pre-fn post-fn paths ctx]
   (->> (keys deps)
        (map (partial pre-fn ctx paths))
        ((juxt (partial reduce (fn [clj-dirs [_ {:keys [parent-clj-dirs]}]] (into clj-dirs parent-clj-dirs)) []) reverse))
        ((fn [[clj-dirs deps]]
-          (dorun (map (fn [[pre-result _]] (post-fn ctx pre-result (update paths :parent-clj-dirs concat clj-dirs))) deps))))))
+          (mapv (fn [[pre-result _]] (post-fn ctx pre-result (update paths :parent-clj-dirs concat clj-dirs))) deps)))))
 
 (defn- create-dep-graph
   ([graph deps level]

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -53,16 +53,6 @@
      (= file-ext extension-of-moved)
      (= file-ext ".cljc"))))
 
-(defn- clojure-source-files [dirs extension]
-  (->> dirs
-       (map io/file)
-       (filter #(.exists ^File %))
-       (mapcat file-seq)
-       (filter (fn [^File file]
-                 (and (.isFile file)
-                      (update? (str file) extension))))
-       (mapv fs/normalized)))
-
 (defn- prefix-libspec [libspec]
   (let [prefix (str/join "." (butlast (str/split (name libspec) #"\.")))]
     (and prefix (symbol prefix))))
@@ -359,6 +349,69 @@
       (str/replace new-source-sans-ns ns-form-placeholder new-ns-form))
      new-source-sans-ns)))
 
+(defn- apply-ns-rename-to-form
+  "Applies one rename to a single ns form (given as a string), with the same cljc
+  platform handling as `replace-ns-symbol`, and returns the rewritten ns-form
+  string. The ns form is small, so reparsing it per rename is cheap - the
+  expensive whole-file split happens once in `replace-ns-symbols`."
+  [ns-form-str {:keys [old-sym new-sym watermark extension]} file-ext]
+  (let [ns-loc             (z/of-string ns-form-str)
+        opposite-platform  (util/platform-comp (util/extension->platform extension))
+        [replaced ns-loc]  (or (and (= ".cljc" file-ext)
+                                    opposite-platform
+                                    (find-and-replace-platform-specific-subforms opposite-platform ns-loc))
+                               [[] ns-loc])
+        new-form           (replace-in-ns-form ns-loc old-sym new-sym watermark)]
+    (if (seq replaced)
+      (restore-platform-specific-subforms opposite-platform replaced new-form)
+      new-form)))
+
+(defn- source-replacement-multi
+  "Like `source-replacement`, but tries each rename in turn and applies the first
+  one that matches the token (the renames are pre-sorted longest-namespace-first
+  so a more specific prefix wins)."
+  [renames match]
+  (reduce (fn [_ {:keys [old-sym new-sym]}]
+            (let [replaced (source-replacement old-sym new-sym match)]
+              (if (= replaced match) match (reduced replaced))))
+          match
+          renames))
+
+(defn- replace-in-source-multi
+  "Rewrites the ns body once for a whole batch of `renames`: a single regex scan
+  whose replacement function dispatches to whichever rename matches each token,
+  instead of one full scan per rename."
+  [source-sans-ns renames]
+  (if (empty? renames)
+    source-sans-ns
+    (let [regex (re-pattern (str (->> renames
+                                      (map #(java.util.regex.Pattern/quote (load-param (:old-sym %))))
+                                      (str/join "|"))
+                                 "|"
+                                 (.pattern ^java.util.regex.Pattern symbol-regex)))]
+      (str/replace source-sans-ns regex (partial source-replacement-multi renames)))))
+
+(defn replace-ns-symbols
+  "Applies a batch of `renames` to one file's `content` in a single pass: the ns
+  form is parsed once and the body scanned once, rather than once per rename.
+  `renames` is a seq of maps {:old-sym :new-sym :watermark :extension}. The
+  result is equivalent to folding `replace-ns-symbol` over the renames, but
+  O(file) instead of O(file x renames)."
+  [content renames file-ext]
+  (if (empty? renames)
+    content
+    ;; longest namespace first so e.g. `a.b.c` is preferred over `a.b` when both
+    ;; could prefix-match the same token
+    (let [renames       (sort-by #(- (count (name (:old-sym %)))) renames)
+          [ns-loc body] (split-ns-form-ns-body content)
+          new-ns-form   (when ns-loc
+                          (reduce (fn [s rename] (apply-ns-rename-to-form s rename file-ext))
+                                  (z/root-string ns-loc)
+                                  renames))
+          new-body      (replace-in-source-multi body renames)]
+      (or (and new-ns-form (str/replace new-body ns-form-placeholder new-ns-form))
+          new-body))))
+
 (defn move-ns-file
   "ALPHA: subject to change. Moves the .clj or .cljc source file (found relative
   to source-path) for the namespace named old-sym to a file for a
@@ -385,18 +438,62 @@
     map
     pmap))
 
+(defn- clojure-source-files-all
+  "All Clojure source files (.clj/.cljc/.cljs) under `dirs`, normalized. Unlike
+  `clojure-source-files` this doesn't filter by a single moved namespace's
+  extension - the per-rename `update?` check is applied later, per file."
+  [dirs]
+  (->> dirs
+       (map io/file)
+       (filter #(.exists ^File %))
+       (mapcat file-seq)
+       (filter (fn [^File file]
+                 (and (.isFile file)
+                      (boolean (util/file->extension (str file))))))
+       (mapv fs/normalized)))
+
+(defn move-ns-files!
+  "Moves the source file(s) for `old-sym` to `new-sym` WITHOUT rewriting any
+  references (also moves a `.cljc` companion when moving a `.clj`/`.cljs`).
+
+  WARNING: moves and deletes source files."
+  [old-sym new-sym source-path extension]
+  (move-ns-file old-sym new-sym extension source-path)
+  ;; move cljc file with the platform specific file if exists
+  (when (and (#{".clj" ".cljs"} extension) (.exists (sym->file source-path old-sym ".cljc")))
+    (move-ns-file old-sym new-sym ".cljc" source-path)))
+
+(defn replace-ns-symbols-in-source-files
+  "Applies a batch of namespace renames to every Clojure source file under
+  `dirs`, reading and writing each file at most once (in parallel, per file).
+
+  `renames` is a seq of maps with `:old-sym`, `:new-sym`, `:extension` (the moved
+  namespace's file extension) and `:watermark`. A rename is applied to a given
+  file only when `update?` holds for that file and the rename's extension - the
+  same per-rename behaviour as applying the renames one at a time, but without
+  re-scanning the directories and re-reading every file once per rename."
+  [renames dirs]
+  (when (seq renames)
+    (let [files (clojure-source-files-all dirs)]
+      (util/assert-no-duplicate-files files)
+      (->> files
+           (pmap-runner
+            (fn [file]
+              (let [file-ext   (util/file->extension (str file))
+                    ;; only the renames whose moved-namespace extension applies to
+                    ;; this file (the per-rename behaviour of `update?`)
+                    applicable (filterv #(update? (str file) (:extension %)) renames)]
+                (when (seq applicable)
+                  (update-file file (fn [content] (replace-ns-symbols content applicable file-ext)))))))
+           (doall)))))
+
 (defn replace-ns-symbol-in-source-files
   "Replaces all occurrences of the old name with the new name in
   all Clojure source files found in dirs."
   [old-sym new-sym extension dirs watermark]
-  (let [files (clojure-source-files dirs extension)]
-    (util/assert-no-duplicate-files files)
-    (->> files
-         (pmap-runner (fn [file]
-                        (->> (str file)
-                             util/file->extension
-                             (update-file file replace-ns-symbol old-sym new-sym watermark extension))))
-         (doall))))
+  (replace-ns-symbols-in-source-files
+   [{:old-sym old-sym :new-sym new-sym :extension extension :watermark watermark}]
+   dirs))
 
 (defn move-ns
   "ALPHA: subject to change. Moves the .clj or .cljc source file (found relative
@@ -410,8 +507,5 @@
   WARNING: This function modifies and deletes your source files! Make
   sure you have a backup or version control."
   [old-sym new-sym source-path extension dirs watermark]
-  (move-ns-file old-sym new-sym extension source-path)
-  ;; move cljc file with the platform specific file if exists
-  (when (and (#{".clj" ".cljs"} extension) (.exists (sym->file source-path old-sym ".cljc")))
-    (move-ns-file old-sym new-sym ".cljc" source-path))
+  (move-ns-files! old-sym new-sym source-path extension)
   (replace-ns-symbol-in-source-files old-sym new-sym extension dirs watermark))

--- a/test/mranderson/benchmark.clj
+++ b/test/mranderson/benchmark.clj
@@ -1,0 +1,83 @@
+(ns mranderson.benchmark
+  "Ad-hoc perf harness for the namespace-rewriting engine. Not part of the normal
+  suite - run explicitly:
+
+    lein test :only mranderson.benchmark/bench-rewriting
+
+  It inlines a realistic dependency tree and reports how many times
+  `replace-ns-symbol-in-source-files` runs (once per moved namespace, N) and the
+  total number of source-file scans those calls perform (sum of dir-set sizes).
+  If total-scans / files is ~N, the rewriting is doing O(files x namespaces) work."
+  (:require [clojure.test :refer [deftest]]
+            [mranderson.core :as core]
+            [mranderson.move :as move]
+            [clojure.java.io :as io]
+            [me.raynes.fs :as fs])
+  (:import java.io.File))
+
+(def ^:private clojure-source-files-all #'move/clojure-source-files-all)
+
+(defn- temp-dir [p]
+  (doto (File/createTempFile p "") (.delete) (.mkdirs)))
+
+(defn- count-source-files [^File dir]
+  (->> (file-seq dir)
+       (filter #(and (.isFile ^File %)
+                     (re-find #"\.cljc?$|\.cljs$" (.getName ^File %))))
+       count))
+
+(defn- inline! [deps src target]
+  (let [opts {:dependencies                deps
+              :source-paths                [(str src)]
+              :target-path                 (str target)
+              :project-prefix              "bench.inlined"
+              :skip-repackage-java-classes true}
+        t0   (System/nanoTime)]
+    (core/inline-deps opts)
+    (/ (- (System/nanoTime) t0) 1e6)))
+
+(defn run-bench [label deps]
+  (let [mk    (fn [] (let [s (temp-dir "bench-src")
+                           m (io/file s "bench" "main.clj")]
+                       (.mkdirs (.getParentFile m))
+                       (spit m "(ns bench.main)")
+                       s))
+        ;; warm: resolve + populate ~/.m2 so the timed run isn't dominated by downloads
+        warm-s (mk) warm-t (temp-dir "bench-target")
+        _      (inline! deps warm-s warm-t)
+        files  (count-source-files (io/file warm-t "srcdeps"))
+        _      (do (fs/delete-dir warm-s) (fs/delete-dir warm-t))
+        ;; clean timed run
+        time-s (mk) time-t (temp-dir "bench-target")
+        ms     (inline! deps time-s time-t)
+        _      (do (fs/delete-dir time-s) (fs/delete-dir time-t))
+        ;; instrumented run: count rewrite passes and total file-reads. With the
+        ;; global single pass this should be 1 pass and ~1 read per file; a
+        ;; regression to per-artifact passes would show up as many of both.
+        calls   (atom 0) scans (atom 0) rw-ms (atom 0.0)
+        inst-s (mk) inst-t (temp-dir "bench-target")
+        orig    move/replace-ns-symbols-in-source-files]
+    (with-redefs [move/replace-ns-symbols-in-source-files
+                  (fn [renames dirs]
+                    (swap! calls inc)
+                    (swap! scans + (count (clojure-source-files-all dirs)))
+                    (let [t (System/nanoTime)
+                          r (orig renames dirs)]
+                      (swap! rw-ms + (/ (- (System/nanoTime) t) 1e6))
+                      r))]
+      (inline! deps inst-s inst-t))
+    (fs/delete-dir inst-s) (fs/delete-dir inst-t)
+    (println (format (str "\n[BENCH %s]\n  inline time (total): %.0f ms\n  files (F): %d\n"
+                          "  rewrite passes: %d   total file-reads: %d (~%.1f per file)\n"
+                          "  time in rewriting: %.0f ms  (%.0f%% of total)\n")
+                     label ms files @calls @scans
+                     (double (/ @scans (max 1 files)))
+                     @rw-ms (* 100.0 (/ @rw-ms ms))))))
+
+(deftest ^:benchmark bench-rewriting
+  ;; MrAnderson's own dependency tree - a realistic, reproducible large workload.
+  (run-bench "mranderson-deps"
+             '[[clj-commons/pomegranate "1.2.25"]
+               [org.clojure/tools.namespace "1.5.1"]
+               [clj-commons/fs "1.6.312"]
+               [rewrite-clj "1.2.54"]]))


### PR DESCRIPTION
Audit batch 5, the real perf win - benchmark-driven.

**The finding.** Namespace rewriting was O(files x namespaces). Each dependency's rewrite pass re-scanned and re-parsed every file in its dir scope, and those scopes overlap heavily (a dep rewrites references to itself in its dependents' dirs too). So the *same* file was parsed with rewrite-clj once per artifact whose scope covered it. A benchmark on MrAnderson's own dependency tree: **88 files parsed ~12x each - 10,830 file-reads across 174 rewrite passes.** (Neither I/O nor regex was the bottleneck - it was the redundant parsing, which is why the obvious I/O/regex tweaks did nothing.)

**The fix.** In resolved-tree mode (the default) the old->new rename map is 1:1, so the per-artifact dir scoping is unnecessary. Now each artifact just *moves* its files and returns its renames; references are rewritten across all of `srcdeps` in **one pass that parses each file exactly once**. A new combined per-file rewrite (`replace-ns-symbols` / `source-replacement-multi`) applies *all* renames in a single ns-form parse + single body scan, so one global sweep doesn't reintroduce the M-per-file cost. Unresolved-tree mode keeps its per-subtree rewriting (there the same namespace is copied to many nested locations with location-dependent prefixes).

**Result (benchmark):**

| | master | this PR |
|---|---|---|
| rewrite passes | 174 | **1** |
| file-reads (88 files) | 10,830 (~123x) | **88 (1x)** |
| total inline | ~5.16s | **~3.4s (~34% faster)** |

No behaviour change - the same resolved/unresolved/cljc/java-import/move-ns tests pass, eastwood is clean. Includes a `mranderson.benchmark` harness (excluded from normal CI; `lein test :benchmark`) that guards against regressing back to many passes.

Given this touches the rewriting engine and the resolved-tree orchestrator, I'd value a careful look - the CI matrix and the hard `make install` self-inline both exercise it.