### PR TITLE
Dispatch ns-body tokens to renames by first segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Speed up inlining by rewriting namespace references in a single pass: in resolved-tree mode every source file is now parsed once instead of once per dependency whose scope overlapped it (it was effectively O(files x namespaces))
+- Speed up inlining (roughly 2x on a medium dependency tree) by rewriting namespace references in a single pass: in resolved-tree mode every source file is now parsed once instead of once per dependency whose scope overlapped it (it was effectively O(files x namespaces)), and each file's tokens are dispatched to the matching rename by first segment rather than checked against every rename
 
 ## 0.6.0
 

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -366,30 +366,55 @@
       (restore-platform-specific-subforms opposite-platform replaced new-form)
       new-form)))
 
+(defn- ns-first-segments
+  "The first path segment of a namespace, in both its namespace (dash) and
+  package/path (underscore) spellings. Every token `source-replacement` could
+  rewrite for a rename - a namespace ref, a fully-qualified class, a type hint or
+  a `load` path - starts with one of these, so they're enough to index by."
+  [old-sym]
+  (let [seg (first (str/split (name old-sym) #"\."))]
+    (cond-> #{seg}
+      (str/includes? seg "-") (conj (str/replace seg "-" "_")))))
+
+(defn- token-first-segment
+  "The first segment of a matched token, ignoring a leading quote or type-hint
+  caret, for lookup against `ns-first-segments`."
+  [match]
+  (-> match
+      (str/replace #"^[\"^]+" "")
+      (str/split #"[./]")
+      first))
+
 (defn- source-replacement-multi
-  "Like `source-replacement`, but tries each rename in turn and applies the first
-  one that matches the token (the renames are pre-sorted longest-namespace-first
-  so a more specific prefix wins)."
-  [renames match]
+  "Applies the first of `match`'s candidate renames that rewrites it. `by-segment`
+  maps a first segment to the renames whose namespace starts with it; candidates
+  are pre-sorted longest-namespace-first so a more specific prefix wins. Tokens
+  whose first segment matches no rename (the vast majority) are returned as-is
+  without touching any rename."
+  [by-segment match]
   (reduce (fn [_ {:keys [old-sym new-sym]}]
             (let [replaced (source-replacement old-sym new-sym match)]
               (if (= replaced match) match (reduced replaced))))
           match
-          renames))
+          (get by-segment (token-first-segment match))))
 
 (defn- replace-in-source-multi
   "Rewrites the ns body once for a whole batch of `renames`: a single regex scan
-  whose replacement function dispatches to whichever rename matches each token,
-  instead of one full scan per rename."
+  whose replacement function dispatches by first segment to whichever rename
+  matches each token, instead of one full scan per rename."
   [source-sans-ns renames]
   (if (empty? renames)
     source-sans-ns
-    (let [regex (re-pattern (str (->> renames
-                                      (map #(java.util.regex.Pattern/quote (load-param (:old-sym %))))
-                                      (str/join "|"))
-                                 "|"
-                                 (.pattern ^java.util.regex.Pattern symbol-regex)))]
-      (str/replace source-sans-ns regex (partial source-replacement-multi renames)))))
+    (let [by-segment (reduce (fn [m rename]
+                               (reduce #(update %1 %2 (fnil conj []) rename)
+                                       m (ns-first-segments (:old-sym rename))))
+                             {} renames)
+          regex      (re-pattern (str (->> renames
+                                           (map #(java.util.regex.Pattern/quote (load-param (:old-sym %))))
+                                           (str/join "|"))
+                                      "|"
+                                      (.pattern ^java.util.regex.Pattern symbol-regex)))]
+      (str/replace source-sans-ns regex (partial source-replacement-multi by-segment)))))
 
 (defn replace-ns-symbols
   "Applies a batch of `renames` to one file's `content` in a single pass: the ns


### PR DESCRIPTION
Round 2, perf finisher (follow-up to the single-pass rewrite).

The global single pass applies every rename to every file, so the body rewrite was checking each token against all ~170 renames via `source-replacement`. Most tokens (locals, `clojure.core` fns, keywords) match nothing, but still paid that full O(renames) cost per token.

This indexes the renames by their namespace's **first segment** - in both the dash (namespace) and underscore (package/path) spellings, which covers every token form `source-replacement` can rewrite (ns ref, fully-qualified class, type hint, `load` path). A token is looked up by its own first segment, so a non-matching token costs one set lookup, and a matching one only checks the handful of renames sharing that segment.

**Benchmark (MrAnderson's own deps):** rewriting ~2.4s -> ~1.7s, total inline ~3.3s -> ~2.6s. Cumulative with the single-pass change already on master: **~5.2s -> ~2.6s, ~2x faster.**

No behaviour change - a token can only ever match renames that share its first segment, so the index can't hide a real match (false positives just fall through to the same per-rename check as before). Eastwood clean, full suite green; `lein test :benchmark` guards it.