### PR TITLE
Prefix body-only Java class references with no :import form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- [#97](https://github.com/benedekfazekas/mranderson/issues/97) Prefix repackaged Java classes referenced in a namespace body even when the file has no `(:import ...)` form (previously such references were left bare and threw `ClassNotFoundException` at runtime)
+
 ### Changes
 
 - Speed up inlining (roughly 2x on a medium dependency tree) by rewriting namespace references in a single pass: in resolved-tree mode every source file is now parsed once instead of once per dependency whose scope overlapped it (it was effectively O(files x namespaces)), and each file's tokens are dispatched to the matching rename by first segment rather than checked against every rename

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -215,11 +215,15 @@
   rewritten class-exactly (see `rewrite-import-spec`); in the rest of the file
   classes appear fully qualified, so the exact class names are prefixed. The
   import fragment is swapped out for a placeholder while the body is rewritten so
-  it isn't processed twice. Returns `content` unchanged when `orig-import` is
-  blank."
+  it isn't processed twice.
+
+  When there is no `(:import …)` form the body is still rewritten: a file can
+  reference a repackaged class fully qualified in its body without importing it
+  (e.g. `(org.httpkit.PrefixThreadFactory. …)`), and those references must be
+  prefixed too or they throw `ClassNotFoundException` at runtime. See #97."
   [content orig-import class-names cleaned-name-version]
   (if (str/blank? orig-import)
-    content
+    (prefix-occurrences content class-names cleaned-name-version)
     (let [class-set  (set class-names)
           new-import (rewrite-import-form orig-import class-set cleaned-name-version)
           uuid       (str (UUID/randomUUID))]

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -253,8 +253,14 @@
                                    "(:import com.example.Widget)"
                                    ["com.example.Widget"] prefix))))
 
-    (testing "a blank import fragment leaves the content untouched"
-      (is (= "(ns foo)" (rewrite-java-imports "(ns foo)" "" ["com.example.Widget"] prefix))))
+    (testing "#97: a repackaged class referenced in the body is prefixed even with no :import form"
+      (is (= "(ns foo)\n(defn make [] (mrt010.com.example.Widget. 1))"
+             (rewrite-java-imports "(ns foo)\n(defn make [] (com.example.Widget. 1))"
+                                   "" ["com.example.Widget"] prefix)))
+      (testing "but a class that isn't repackaged is left alone"
+        (is (= "(ns foo)\n(defn make [] (com.example.Widget. 1))"
+               (rewrite-java-imports "(ns foo)\n(defn make [] (com.example.Widget. 1))"
+                                     "" ["com.other.Thing"] prefix)))))
 
     (testing "every class in a prefix-list is repackaged: the package is prefixed, no split"
       (is (= "(ns foo\n  (:import [mrt010.com.example Widget Gadget]))"


### PR DESCRIPTION
Fixes #97.

`rewrite-java-imports` only prefixed a file's fully-qualified Java class references when the file *also* had an `(:import …)` form - the body-prefixing was gated behind a non-blank import fragment and otherwise returned the content untouched. So a namespace that references a repackaged class in its body without importing it (e.g. http-kit's `org.httpkit.utils` doing `(org.httpkit.PrefixThreadFactory. …)`) was left bare and threw `ClassNotFoundException` at runtime.

The fix runs the body class-name prefixing unconditionally; only the `(:import …)` form rewrite (and its placeholder swap) stays gated on a non-blank fragment.

Safe by construction: `prefix-occurrences` only prefixes exact repackaged `.class` names (a namespace like `org.httpkit.utils` has no `.class`, so it's never in the class-name set) and skips any occurrence already preceded by a dot, so it can't corrupt real namespace references or double-prefix. It uses the same `clean-name-version` (jarjar) prefix the relocated classes get, so source and classes agree.

http-kit 2.8.1 happened to have an `:import` in that very file, which masked the bug - so the regression test pins the import-less body-reference case directly at the `rewrite-java-imports` level (no network dep). Full suite green, eastwood clean.

Diagnosis credit: reproduced end-to-end against http-kit 2.8.1 with distinct namespace-vs-jarjar prefixes to confirm the rewrite targets the correct (jarjar) prefix and that the only gap was the import-less body path.