### PR TITLE
Split mixed deftype/java imports under a shared, already-prefixed package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- [#33](https://github.com/benedekfazekas/mranderson/issues/33) Split a mixed `(:import ...)` correctly when a deftype class and a repackaged Java class share a package (e.g. claypoole): the Java class now points at its jarjar package even though the namespace move has already prefixed the shared package
 - [#97](https://github.com/benedekfazekas/mranderson/issues/97) Prefix repackaged Java classes referenced in a namespace body even when the file has no `(:import ...)` form (previously such references were left bare and threw `ClassNotFoundException` at runtime)
 
 ### Changes

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -167,33 +167,51 @@
           s
           tokens))
 
+(defn- repackaged-java-package
+  "If `class` imported under `pkg` is one of the repackaged java classes
+  (`class-names`, the original fully-qualified `.class` names), returns that
+  class's original java package; otherwise nil.
+
+  The package is matched as a suffix of `pkg`, not exactly: when a java class
+  shares a package with a Clojure namespace (e.g. claypoole's
+  `com.climate.claypoole.impl`), the namespace move has already prefixed `pkg`
+  by the time imports are rewritten, so the bare java package only appears at
+  the end of `pkg`. See #33."
+  [pkg class class-names]
+  (some (fn [fqn]
+          (when (str/ends-with? fqn (str "." class))
+            (let [jpkg (subs fqn 0 (- (count fqn) (count class) 1))]
+              (when (or (= pkg jpkg) (str/ends-with? pkg (str "." jpkg)))
+                jpkg))))
+        class-names))
+
 (defn- rewrite-import-spec
   "Rewrites a single `(:import …)` spec class-exactly, returning a seq of specs.
 
-  A prefix-list `[pkg C1 C2 …]` is split so only the classes actually in
-  `class-names` get the `prefix`-ed package, leaving the rest under the original
-  package. This both avoids prefixing classes that merely share a package with a
-  repackaged one (#52) and keeps deftype-generated classes - which are prefixed
-  separately by the namespace move - in their original group (#33). A
-  fully-qualified class symbol is prefixed iff it is in `class-names`."
+  A prefix-list `[pkg C1 C2 …]` is split so the repackaged java classes move to
+  their jarjar package (`prefix` + the original java package) while the rest stay
+  under `pkg`. This avoids prefixing classes that merely share a package with a
+  repackaged one (#52) and keeps deftype-generated classes - prefixed separately
+  by the namespace move - under the (namespace-prefixed) package they already
+  have (#33). A fully-qualified class symbol is handled the same way."
   [spec class-names prefix]
   (cond
     (vector? spec)
-    (let [pkg     (first spec)
+    (let [pkg     (str (first spec))
           classes (rest spec)]
       (if (empty? classes)
         [spec]
-        (let [grouped (group-by #(contains? class-names (str pkg "." %)) classes)
-              members (seq (get grouped true))
-              others  (seq (get grouped false))]
+        (let [grouped (group-by #(repackaged-java-package pkg (str %) class-names) classes)
+              others  (seq (get grouped nil))]
           (cond-> []
-            others  (conj (into [pkg] others))
-            members (conj (into [(symbol (str prefix "." pkg))] members))))))
+            others (conj (into [(first spec)] others))
+            true   (into (for [[jpkg cls] (dissoc grouped nil)]
+                           (into [(symbol (str prefix "." jpkg))] cls)))))))
 
     (symbol? spec)
-    [(if (contains? class-names (str spec))
-       (symbol (str prefix "." spec))
-       spec)]
+    (let [s    (str spec)
+          jfqn (some #(when (or (= s %) (str/ends-with? s (str "." %))) %) class-names)]
+      [(if jfqn (symbol (str prefix "." jfqn)) spec)])
 
     :else
     [spec]))

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -424,3 +424,30 @@
         (testing "returns the surviving files (correctly-placed dup + the unique one)"
           (is (= #{"riddley/compiler.clj" "other.clj"} kept))))
       (finally (fs/delete-dir dir)))))
+
+(deftest t-mixed-deftype-java-import-is-split
+  ;; #33: claypoole's main namespace imports both PriorityThreadpool (a deftype,
+  ;; which moves with its namespace) and PriorityThreadpoolImpl (a real java
+  ;; class, repackaged by jarjar) from a single package. They need different
+  ;; prefixes, so the import must be split - and the split has to survive the
+  ;; namespace move having already prefixed the shared package.
+  (with-mranderson
+    [project {:dependencies '[^:inline-dep [com.climate/claypoole "1.1.4"]]
+              :files         []
+              :opts          {:unresolved-tree false}}]
+    (let [{:keys [working-directory prefix]} project
+          name-version (util/clean-name-version "mranderson-test" "0.1.0-SNAPSHOT")
+          content      (slurp (io/file working-directory prefix
+                                       "claypoole" "v1v1v4" "com" "climate" "claypoole.clj"))]
+      (testing "the java class is imported from its jarjar-repackaged package"
+        (is (string/includes?
+             content
+             (str "[" name-version ".com.climate.claypoole.impl PriorityThreadpoolImpl]"))))
+      (testing "the deftype class stays under the namespace-moved package"
+        (is (string/includes?
+             content
+             (str "[" prefix ".claypoole.v1v1v4.com.climate.claypoole.impl PriorityThreadpool]"))))
+      (testing "the java class is not left under the namespace prefix (the #33 bug)"
+        (is (not (string/includes?
+                  content
+                  (str prefix ".claypoole.v1v1v4.com.climate.claypoole.impl PriorityThreadpoolImpl"))))))))


### PR DESCRIPTION
Fixes #33.

You asked me to verify before closing #33 - and the end-to-end test showed it was **still broken**. Inlining claypoole (whose main namespace imports both `PriorityThreadpool`, a deftype, and `PriorityThreadpoolImpl`, a compiled java class, from `com.climate.claypoole.impl`) produced:

```
(:import [PREFIX.claypoole.v1v1v4.com.climate.claypoole.impl PriorityThreadpool PriorityThreadpoolImpl] …)
```

Both classes ended up under the **namespace** prefix, but the java class's `.class` is jarjar-relocated to the **`clean-name-version`** prefix - so `PriorityThreadpoolImpl` was a `ClassNotFoundException` at runtime. (This is why you dropped libraries like this.)

Root cause: the class-exact import split from #108 matched the java class by its bare fully-qualified name, but the namespace move runs first and rewrites the shared package to the namespace prefix, so the java class no longer matched and never got split out.

Fix: match the repackaged java package as a **suffix** of the import package, so the java class is still recognised after the namespace move has prefixed the package, and split it back to its jarjar package. After the fix:

```
(:import [PREFIX.claypoole.v1v1v4.com.climate.claypoole.impl PriorityThreadpool]
         [CLEANNAMEVERSION.com.climate.claypoole.impl PriorityThreadpoolImpl] …)
```

Each class now points where it actually lives. Includes an end-to-end regression test that inlines claypoole with repackaging on; the existing #52/#33/#108 import unit tests still pass unchanged. Full suite green, eastwood clean.