### PR TITLE
Don't namespace-prefix fully-qualified repackaged Java class refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- Leave a fully-qualified reference to a repackaged Java class (e.g. `(some.pkg.Widget. ...)`) untouched during the namespace move when its package is also a moved namespace, so the java-import pass can point it at the jarjar-repackaged class instead of the namespace prefix (otherwise it threw `ClassNotFoundException` at runtime). Deftype/defrecord classes, which have no `.class` file, still move with their namespace
 - [#33](https://github.com/benedekfazekas/mranderson/issues/33) Split a mixed `(:import ...)` correctly when a deftype class and a repackaged Java class share a package (e.g. claypoole): the Java class now points at its jarjar package even though the namespace move has already prefixed the shared package
 - [#97](https://github.com/benedekfazekas/mranderson/issues/97) Prefix repackaged Java classes referenced in a namespace body even when the file has no `(:import ...)` form (previously such references were left bare and threw `ClassNotFoundException` at runtime)
 

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -77,6 +77,14 @@
     (when-not (= old new)
       (spit file new))))
 
+(defn- java-class-fqns
+  "Fully-qualified names of every bundled `.class` under `srcdeps` (their
+  original packages, before jarjar relocates them). The namespace move leaves
+  references to these untouched so the java-import pass can point them at the
+  repackaged classes. See #97."
+  [srcdeps]
+  (into #{} (map (partial u/class-file->fully-qualified-name srcdeps)) (u/class-files srcdeps)))
+
 (defn- import-fragment-left [^String clj-source]
   (let [index-of-import (.indexOf clj-source ":import")]
     (when (> index-of-import -1)
@@ -324,12 +332,14 @@
       (if-not unresolved-tree
         renames
         (let [all-deps-dirs (->> (concat [src-path] (map fs/file clj-dirs) parent-clj-dirs)
-                                 vec (mapv str) u/normalize-dirs (mapv fs/file))]
-          (move/replace-ns-symbols-in-source-files renames all-deps-dirs)
+                                 vec (mapv str) u/normalize-dirs (mapv fs/file))
+              java-classes  (java-class-fqns srcdeps)]
+          (move/replace-ns-symbols-in-source-files renames all-deps-dirs java-classes)
           (when (or (str/ends-with? src-path (u/sym->file-name pprefix)) expose?)
             (move/replace-ns-symbols-in-source-files
              (mapv #(assoc % :watermark nil) renames)
-             project-source-dirs))
+             project-source-dirs
+             java-classes))
           nil)))))
 
 (defn- remove-invalid-duplicates!
@@ -428,7 +438,7 @@
     ;; rather than once per artifact whose dir scope overlaps it.
     (let [renames (->> (t/walk-ordered-deps ordered-resolved-deps unzip-artifact! update-artifact! paths ctx)
                        (apply concat))]
-      (move/replace-ns-symbols-in-source-files renames [(:srcdeps ctx)]))))
+      (move/replace-ns-symbols-in-source-files renames [(:srcdeps ctx)] (java-class-fqns (:srcdeps ctx))))))
 
 (defn mranderson
   "Inline and shadow dependencies so they can not interfere with other libraries' dependencies.

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -390,19 +390,32 @@
   maps a first segment to the renames whose namespace starts with it; candidates
   are pre-sorted longest-namespace-first so a more specific prefix wins. Tokens
   whose first segment matches no rename (the vast majority) are returned as-is
-  without touching any rename."
-  [by-segment match]
-  (reduce (fn [_ {:keys [old-sym new-sym]}]
-            (let [replaced (source-replacement old-sym new-sym match)]
-              (if (= replaced match) match (reduced replaced))))
-          match
-          (get by-segment (token-first-segment match))))
+  without touching any rename.
+
+  A token that is a repackaged Java class (`java-classes`, the fully-qualified
+  `.class` names) is left untouched even when its package is a moved namespace:
+  it must keep pointing at the class, which jarjar relocates to a different
+  prefix, so the java-import pass prefixes it instead. Deftype classes have no
+  `.class` and so move with their namespace as usual. See #97."
+  [by-segment java-classes match]
+  (let [candidates (get by-segment (token-first-segment match))]
+    (if (or (empty? candidates)
+            ;; strip a leading quote/caret and a trailing dot (constructor form
+            ;; `Class.`) so the bare class name is matched
+            (contains? java-classes (-> match (str/replace #"^[\"^]+" "") (str/replace #"\.$" ""))))
+      match
+      (reduce (fn [_ {:keys [old-sym new-sym]}]
+                (let [replaced (source-replacement old-sym new-sym match)]
+                  (if (= replaced match) match (reduced replaced))))
+              match
+              candidates))))
 
 (defn- replace-in-source-multi
   "Rewrites the ns body once for a whole batch of `renames`: a single regex scan
   whose replacement function dispatches by first segment to whichever rename
-  matches each token, instead of one full scan per rename."
-  [source-sans-ns renames]
+  matches each token, instead of one full scan per rename. References to
+  repackaged Java classes (`java-classes`) are left for the java-import pass."
+  [source-sans-ns renames java-classes]
   (if (empty? renames)
     source-sans-ns
     (let [by-segment (reduce (fn [m rename]
@@ -414,28 +427,31 @@
                                            (str/join "|"))
                                       "|"
                                       (.pattern ^java.util.regex.Pattern symbol-regex)))]
-      (str/replace source-sans-ns regex (partial source-replacement-multi by-segment)))))
+      (str/replace source-sans-ns regex (partial source-replacement-multi by-segment java-classes)))))
 
 (defn replace-ns-symbols
   "Applies a batch of `renames` to one file's `content` in a single pass: the ns
   form is parsed once and the body scanned once, rather than once per rename.
   `renames` is a seq of maps {:old-sym :new-sym :watermark :extension}. The
   result is equivalent to folding `replace-ns-symbol` over the renames, but
-  O(file) instead of O(file x renames)."
-  [content renames file-ext]
-  (if (empty? renames)
-    content
-    ;; longest namespace first so e.g. `a.b.c` is preferred over `a.b` when both
-    ;; could prefix-match the same token
-    (let [renames       (sort-by #(- (count (name (:old-sym %)))) renames)
-          [ns-loc body] (split-ns-form-ns-body content)
-          new-ns-form   (when ns-loc
-                          (reduce (fn [s rename] (apply-ns-rename-to-form s rename file-ext))
-                                  (z/root-string ns-loc)
-                                  renames))
-          new-body      (replace-in-source-multi body renames)]
-      (or (and new-ns-form (str/replace new-body ns-form-placeholder new-ns-form))
-          new-body))))
+  O(file) instead of O(file x renames). `java-classes` (optional) are
+  fully-qualified repackaged Java class names left untouched in the body."
+  ([content renames file-ext]
+   (replace-ns-symbols content renames file-ext #{}))
+  ([content renames file-ext java-classes]
+   (if (empty? renames)
+     content
+     ;; longest namespace first so e.g. `a.b.c` is preferred over `a.b` when both
+     ;; could prefix-match the same token
+     (let [renames       (sort-by #(- (count (name (:old-sym %)))) renames)
+           [ns-loc body] (split-ns-form-ns-body content)
+           new-ns-form   (when ns-loc
+                           (reduce (fn [s rename] (apply-ns-rename-to-form s rename file-ext))
+                                   (z/root-string ns-loc)
+                                   renames))
+           new-body      (replace-in-source-multi body renames java-classes)]
+       (or (and new-ns-form (str/replace new-body ns-form-placeholder new-ns-form))
+           new-body)))))
 
 (defn move-ns-file
   "ALPHA: subject to change. Moves the .clj or .cljc source file (found relative
@@ -496,21 +512,26 @@
   namespace's file extension) and `:watermark`. A rename is applied to a given
   file only when `update?` holds for that file and the rename's extension - the
   same per-rename behaviour as applying the renames one at a time, but without
-  re-scanning the directories and re-reading every file once per rename."
-  [renames dirs]
-  (when (seq renames)
-    (let [files (clojure-source-files-all dirs)]
-      (util/assert-no-duplicate-files files)
-      (->> files
-           (pmap-runner
-            (fn [file]
-              (let [file-ext   (util/file->extension (str file))
-                    ;; only the renames whose moved-namespace extension applies to
-                    ;; this file (the per-rename behaviour of `update?`)
-                    applicable (filterv #(update? (str file) (:extension %)) renames)]
-                (when (seq applicable)
-                  (update-file file (fn [content] (replace-ns-symbols content applicable file-ext)))))))
-           (doall)))))
+  re-scanning the directories and re-reading every file once per rename.
+
+  `java-classes` (optional) are fully-qualified repackaged Java class names that
+  the rewrite must leave untouched (they are prefixed by the java-import pass)."
+  ([renames dirs]
+   (replace-ns-symbols-in-source-files renames dirs #{}))
+  ([renames dirs java-classes]
+   (when (seq renames)
+     (let [files (clojure-source-files-all dirs)]
+       (util/assert-no-duplicate-files files)
+       (->> files
+            (pmap-runner
+             (fn [file]
+               (let [file-ext   (util/file->extension (str file))
+                     ;; only the renames whose moved-namespace extension applies to
+                     ;; this file (the per-rename behaviour of `update?`)
+                     applicable (filterv #(update? (str file) (:extension %)) renames)]
+                 (when (seq applicable)
+                   (update-file file (fn [content] (replace-ns-symbols content applicable file-ext java-classes)))))))
+            (doall))))))
 
 (defn replace-ns-symbol-in-source-files
   "Replaces all occurrences of the old name with the new name in

--- a/test/mranderson/benchmark.clj
+++ b/test/mranderson/benchmark.clj
@@ -58,11 +58,11 @@
         inst-s (mk) inst-t (temp-dir "bench-target")
         orig    move/replace-ns-symbols-in-source-files]
     (with-redefs [move/replace-ns-symbols-in-source-files
-                  (fn [renames dirs]
+                  (fn [renames dirs & more]
                     (swap! calls inc)
                     (swap! scans + (count (clojure-source-files-all dirs)))
                     (let [t (System/nanoTime)
-                          r (orig renames dirs)]
+                          r (apply orig renames dirs more)]
                       (swap! rw-ms + (/ (- (System/nanoTime) t) 1e6))
                       r))]
       (inline! deps inst-s inst-t))

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -2,6 +2,7 @@
   (:require [mranderson.move :as sut]
             [clojure.test :as t]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [rewrite-clj.zip :as z])
   (:import [java.io File]))
 
@@ -402,3 +403,21 @@
       ;; the dash in the prefix becomes an underscore, like a package path
       "(load \"/cider/nrepl/inlined_deps/instaparse/gll/extra\")"
       "(load \"/instaparse/gll/extra\")")))
+
+(t/deftest replace-ns-symbols-leaves-java-classes-for-the-import-pass
+  ;; A fully-qualified reference to a repackaged java class whose package is also
+  ;; a moved namespace must be left bare by the namespace move, so the java-import
+  ;; pass can point it at the jarjar-relocated class rather than the (wrong)
+  ;; namespace prefix. Deftype classes have no .class and so are not in
+  ;; `java-classes`, and still move with their namespace.
+  (let [renames [{:old-sym 'com.acme.impl :new-sym 'pre.com.acme.impl
+                  :extension ".clj" :watermark nil}]
+        body    "(ns com.acme.impl)\n(defn make [] (com.acme.impl.Widget. 1))"]
+    (t/testing "a java class (in java-classes) is left untouched in the body"
+      (t/is (str/includes?
+             (sut/replace-ns-symbols body renames ".clj" #{"com.acme.impl.Widget"})
+             "(com.acme.impl.Widget. 1)")))
+    (t/testing "without that knowledge the move prefixes the ref (the latent bug)"
+      (t/is (str/includes?
+             (sut/replace-ns-symbols body renames ".clj")
+             "pre.com.acme.impl.Widget.")))))


### PR DESCRIPTION
Proactive hardening of the Java-class / namespace overlap (same family as #33 and #97). You asked me to confirm with a repro first - it's a real, latent runtime bug.

**Repro (synthetic dep):** a `.class` (`com.acme.impl.Widget`) plus a namespace `com.acme.impl` that references it fully-qualified with no import: `(defn make [] (com.acme.impl.Widget. 1))`. Inlining it, the body ref came out as:

```
(mranderson_test….com.acme.impl.Widget. 1)   ;; namespace prefix
```

…but `Widget.class` is jarjar-relocated to `mrandersontest010SNAPSHOT.com.acme.impl.Widget` - so it's a `ClassNotFoundException` at runtime. The namespace move treats the fully-qualified Java ref as a member of the moved namespace `com.acme.impl` and prefixes it.

(claypoole/http-kit dodged this: claypoole uses unqualified imported refs, http-kit's `org.httpkit` isn't a moved namespace. But the combination is plausible and silently broken.)

**Fix:** thread the set of bundled `.class` fully-qualified names into the rewrite and skip any token that names one - the namespace move leaves it bare, and the existing java-import pass (#97) prefixes it to the repackaged class. Deftype/defrecord classes have no `.class`, so they're not in the set and still move with their namespace (the existing `move-ns-test` fully-qualified deftype refs cover that and still pass). After the fix the ref comes out as `mrandersontest010SNAPSHOT.com.acme.impl.Widget.`, matching the class.

Regression test pins it at the `replace-ns-symbols` level (CI-friendly - the synthetic dep isn't published; the end-to-end was confirmed manually). No perf change (benchmark steady at ~2.6s). Full suite green, eastwood clean.