### PR TITLE
Expand the docs: design, rationale, contributing, agents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Keep it short and conversational. Explain why, not a file-by-file list. -->
+
+## What and why
+
+<!-- 1-3 sentences. What does this change and why is it needed?
+     Reference related issues with "Fixes #NN" or "Closes #NN". -->
+
+## Checklist
+
+- [ ] Tests added or updated (for engine changes, prefer an end-to-end inlining test)
+- [ ] `lein test` passes
+- [ ] `lein with-profile +eastwood eastwood` is clean (it lints tests too)
+- [ ] `CHANGELOG.md` updated under `Unreleased` (for user-facing changes)
+- [ ] Ran `lein test :benchmark` if the rewriting engine changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Humans: see
+[CONTRIBUTING.md](CONTRIBUTING.md) and [doc/design.md](doc/design.md), which this
+file deliberately summarizes rather than duplicates.
+
+## What this is
+
+MrAnderson is a Clojure dependency inlining ("shading") tool: it copies a
+project's dependencies under a private prefix and rewrites every namespace and
+reference so the copies can't collide with anyone else's. Output lands in
+`target/srcdeps`. Read [doc/design.md](doc/design.md) before touching the engine.
+
+## Repo map
+
+| Path | What lives there |
+|------|------------------|
+| `src/mranderson/core.clj` | the pipeline / orchestration, and the `inline-deps` entry point |
+| `src/mranderson/move.clj` | the namespace + reference rewriting engine (the subtle part) |
+| `src/mranderson/util.clj` | file helpers, jarjar invocation |
+| `src/mranderson/dependency/` | dependency resolution (`resolver`) and tree walking (`tree`) |
+| `src/leiningen/inline_deps.clj`, `src/mranderson/plugin.clj` | the Leiningen task and middleware |
+| `java-src/mranderson/util/` | vendored Jar Jar Links glue (don't reformat) |
+| `test/` | the suite; `mranderson.benchmark` is the perf harness |
+
+## Commands
+
+```
+lein test                                  # full suite (hits the network; slower first run)
+lein test :only mranderson.move-test/move-ns-test   # a single test
+lein test :benchmark                       # the perf benchmark (excluded from the normal run)
+lein with-profile +eastwood eastwood       # lint
+make install                               # the real end-to-end test: inline MrAnderson into itself
+```
+
+## Gotchas (read these)
+
+- **Eastwood lints the test namespaces and CI fails on any warning, including
+  reflection.** Run eastwood locally after editing tests, or you'll turn the
+  build red with something like an untyped `.indexOf`.
+- **`test-resources/c` gets written to by a copy test.** If `git status` is dirty
+  there after a run, reset with `git checkout -- test-resources/c`. Don't commit
+  it.
+- **The build is self-hosting.** MrAnderson inlines its own deps using itself, so
+  it depends on itself as a plugin. The `Makefile` manages the bootstrap; use it
+  rather than fighting `lein` directly for the inlined build.
+- **The benchmark is your regression guard for the engine.** If you change
+  `mranderson.move`, run `lein test :benchmark` before and after.
+- **Unit tests can pass while the pipeline is broken.** The Java/namespace
+  overlap bugs (#33, #97, and the body-ref variant) all had green unit tests
+  while real inlining failed. For engine changes, add an end-to-end test that
+  inlines a real or synthetic dependency.
+
+## Conventions
+
+- Every behaviour change gets a test.
+- Add a terse `CHANGELOG.md` entry under `Unreleased`, prefixed with the issue/PR
+  link, matching the existing style.
+- Focused commits; explain the *why*; reference issues with `[#NN]` (or
+  `[Fix #NN]` only when the commit fully closes it).
+- Linear history: rebase/fast-forward; rebase-merge for PRs.
+- GitHub markdown does not render `--`; use a regular dash or rephrase.
+- Don't post to GitHub (issues/PRs/comments) without being asked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to MrAnderson
+
+Thanks for wanting to help. MrAnderson is small but the engine is subtle, so this
+guide covers the things that aren't obvious from the code: the self-hosting
+build, how to run the tests, and the conventions we follow.
+
+If you want to understand *how the thing works* before changing it, read the
+[design doc](doc/design.md). It will save you time.
+
+## Prerequisites
+
+- [Leiningen](https://leiningen.org) 2.9.1 or newer.
+- A JDK. CI runs the matrix on JDK 8, 11, 17, and 21, so keep the code compiling
+  on 8 (don't reach for language features newer than that).
+- Linux or macOS. Windows isn't tested or supported.
+
+## Project layout
+
+```
+src/mranderson/core.clj            the pipeline / orchestration
+src/mranderson/move.clj            the namespace + reference rewriting engine
+src/mranderson/util.clj            file helpers, jarjar invocation
+src/mranderson/dependency/         dependency resolution and tree walking
+src/leiningen/inline_deps.clj      the `lein inline-deps` task
+src/mranderson/plugin.clj          Leiningen middleware
+java-src/mranderson/util/          vendored Jar Jar Links glue
+test/                              the test suite
+doc/                               design and rationale docs
+```
+
+## The self-hosting build
+
+MrAnderson inlines its own dependencies using itself, so it depends on itself as
+a Leiningen plugin. That's a chicken-and-egg situation, and the `Makefile` exists
+to manage it. The important targets:
+
+- `make test` runs the unit tests.
+- `make bootstrap-install` installs MrAnderson to your local Maven repo *without*
+  inlining. This is what satisfies the self-dependency on the plugin, so the real
+  inlined build can run.
+- `make inline` bootstraps and then produces an inlined build under
+  `target/srcdeps`.
+- `make install` installs an *inlined* MrAnderson to your local Maven repo, so
+  other projects on your machine can depend on it.
+- `make integration-test` runs the downstream tests against cider-nrepl and
+  refactor-nrepl (see `scripts/integration_test.sh`).
+- `make deploy` deploys an inlined release to Clojars.
+
+For day-to-day work on the engine you mostly want `make test` (or `lein test`).
+You only need the bootstrap dance when you're testing the full inlined build.
+
+## Running the tests
+
+```
+lein test            # the whole suite
+lein test :only mranderson.move-test/move-ns-test    # one test
+```
+
+A few things to know:
+
+- **The suite resolves real dependencies.** Several tests inline actual libraries
+  (cljfmt, riddley, puget, claypoole) to exercise the pipeline end to end, so the
+  first run hits the network and is slower. This is deliberate: these are the
+  tests that catch the bugs that unit tests miss.
+- **The benchmark is separate.** `mranderson.benchmark` is excluded from normal
+  runs. Run it explicitly with `lein test :benchmark`. If you touch the rewriting
+  engine, run it before and after and make sure you didn't regress.
+- **`test-resources/c` gets dirtied.** One of the copy tests writes output under
+  `test-resources/c`. If `git status` shows changes there after a run, that's
+  expected; `git checkout -- test-resources/c` to reset.
+
+## Linting
+
+```
+lein with-profile +eastwood eastwood
+```
+
+The thing that trips people up: **Eastwood lints the test namespaces too**, and
+CI fails the build on *any* warning, including reflection warnings. (Clojure
+warns when it can't tell a value's Java type and has to fall back to reflection;
+CI treats that warning as an error.) So a stray `.indexOf` on an untyped value in
+a test will turn the build red. Run eastwood locally before pushing, especially
+after editing tests. Shell scripts are also linted, with `shellcheck`.
+
+## Continuous integration
+
+`.github/workflows/ci.yml` has four jobs:
+
+- **test** runs the matrix: JDK 8/11/17/21 by Clojure 1.10/1.11/1.12.
+- **lint** runs eastwood and shellcheck.
+- **coverage** runs the suite under kaocha + cloverage and uploads to codecov.
+- **integration** runs `make install` (a hard failure if the self-inline breaks)
+  and then the downstream cider-nrepl/refactor-nrepl tests (a soft failure, since
+  those are occasionally flaky for reasons outside this repo).
+
+The `make install` step is the real end-to-end test: it inlines MrAnderson into
+itself. If your change breaks the engine, that's usually where it shows up.
+
+## Conventions
+
+- **Tests.** Every behaviour change needs a test. For engine bugs, prefer an
+  end-to-end test that inlines a real (or, if needed, synthetic) dependency over a
+  unit test that feeds clean inputs; the latter has a habit of passing while the
+  real pipeline is broken.
+- **Changelog.** Add a terse entry to the `Unreleased` section of
+  `CHANGELOG.md`, prefixed with the issue/PR link, in the style of the existing
+  entries.
+- **Commits.** Focused, logical commits with a message that explains the *why*.
+  Reference issues with `[#NN]`, or `[Fix #NN]` only when the commit fully closes
+  the issue.
+- **History.** We keep history linear: rebase/fast-forward, and rebase-merge for
+  PRs (no merge commits).
+- **Markdown.** GitHub doesn't render `--`. Use a regular dash or rephrase.
+
+## Releasing
+
+Releases go to Clojars as `thomasa/mranderson`. Bump the version, make sure the
+`CHANGELOG` is in order, then `make deploy` (which inlines MrAnderson before
+deploying). Deploys are unsigned and use a Clojars token from the environment.

--- a/README.md
+++ b/README.md
@@ -6,19 +6,31 @@
 
 # MrAnderson
 
-MrAnderson is a dependency inlining and shadowing tool. It isolates the project's dependencies so they can not interfere with other libraries' dependencies.
+MrAnderson is a dependency inlining tool for Clojure. It copies the dependencies you choose into your own project under a private name and rewrites every reference to them, so your copies can't collide with anyone else's on the classpath. (This technique has a few names: inlining, shading, vendoring. They mean the same thing here.)
+
+The problem it solves: the JVM loads one version of any given class, full stop. If two of your dependencies need different, incompatible versions of a third one, something breaks and no amount of version-pinning fixes it. Inlining sidesteps that by giving your copy a name nobody else can clash with.
 
 ## Is it good? Should I use it?
 
 Yes and yes.
 
-Use it if you have dependency conflicts and don't care to solve them. In **unresolved tree** mode MrAnderson creates deeply nested, local dependencies where any subtree is isolated from the rest of the tree therefore the same library can occur several times without conflicting. Or use it if you don't want your library's dependencies to interfere with the dependencies of your users' (leiningen plugins is a good example here). Or if you want to explore a bit more in the hellish land of dependency handling.
+Reach for it when you have a dependency conflict you can't (or don't want to) untangle by hand. The headline case is **unresolved tree** mode, where MrAnderson makes deeply nested, local copies of dependencies so that every subtree is isolated and the same library can appear many times without conflict. It's also the right tool when you don't want your library's dependencies leaking onto your users (Leiningen plugins are the classic example). And it's there if you just want to poke around the darker corners of dependency handling.
+
+If you want the longer story, [Why MrAnderson exists](doc/rationale.md) covers the problem, an honest comparison to the alternatives, and when *not* to reach for it. New to Clojure or the JVM? The [glossary](doc/glossary.md) defines the jargon.
+
+## Documentation
+
+- [Why MrAnderson exists](doc/rationale.md) - the rationale, alternatives, and trade-offs.
+- [How MrAnderson works](doc/design.md) - the architecture and the rewriting engine, for anyone changing the internals.
+- [Glossary](doc/glossary.md) - plain-English definitions of the Clojure/JVM terms used throughout.
+- [Contributing](CONTRIBUTING.md) - building, testing, and the self-hosting bootstrap.
+- API docs and these articles render together on [cljdoc](https://cljdoc.org/d/thomasa/mranderson/CURRENT).
 
 ## Usage
 
-MrAnderson is a leiningen plugin. Put `[thomasa/mranderson "0.6.0"]` into the `:plugins` vector of your project.clj. You can also use it directly not as a leiningen plugin, see [conjure-deps](https://github.com/Olical/conjure-deps) for an example.
+MrAnderson is a [Leiningen](https://leiningen.org) plugin (Leiningen is a common Clojure build tool; `project.clj` is its config file). Put `[thomasa/mranderson "0.6.0"]` into the `:plugins` vector of your `project.clj`. You don't have to use Leiningen, though, see [Using MrAnderson without Leiningen](#using-mranderson-without-leiningen-toolsdeps--toolsbuild) below and [conjure-deps](https://github.com/Olical/conjure-deps) for an example.
 
-Mark some of the dependencies in your dependencies vector in the project's `project.clj` with `^:inline-dep` meta tag. For example:
+Mark the dependencies you want inlined with the `^:inline-dep` metadata tag (only the marked ones get processed). For example:
 
 ```clojure
 :dependencies [[org.clojure/clojure "1.5.1"]
@@ -33,9 +45,9 @@ Then run
 
     $ lein inline-deps
 
-This retrieves and modifies the marked dependencies and copies them to `target/srcdeps` together with the modified project files -- their references to the dependencies need to change too.
+This retrieves the marked dependencies, rewrites them, and copies the result to `target/srcdeps`. Your own project files are copied and rewritten too, since their references to those dependencies have to point at the new inlined names.
 
-After this you can start the REPL in the context of your inlined dependencies
+The `plugin.mranderson/config` profile below puts `target/srcdeps` on the classpath, so the REPL, your tests, and the jar you build all use the inlined copies instead of the originals. Start a REPL in the context of your inlined dependencies with
 
     $ lein with-profile +plugin.mranderson/config repl
 
@@ -47,13 +59,18 @@ Release locally
 
     $ lein with-profile +plugin.mranderson/config install
 
-Release to clojars
+Release to Clojars
 
     $ lein with-profile +plugin.mranderson/config deploy clojars
 
-Alternatively the modified dependencies and project files can be copied back to the source tree and stored in version control. In this case you don't need the above mentioned built in leiningen profile.
+Alternatively the modified dependencies and project files can be copied back to the source tree and stored in version control. In this case you don't need the above mentioned built-in Leiningen profile.
 
 ### Using MrAnderson without Leiningen (tools.deps / tools.build)
+
+Clojure projects tend to use one of two build tools: Leiningen (`project.clj`,
+above) or the Clojure CLI / tools.deps (`deps.edn`). They're alternatives, not
+layers, so use whichever your project already has. Everything above is for
+Leiningen; here's the same thing for tools.deps.
 
 You don't need Leiningen to run MrAnderson. The `mranderson.core/inline-deps`
 function is a plain, data-driven entry point that does the same work as the
@@ -100,9 +117,11 @@ See the docstring of `mranderson.core/inline-deps` for the full list of options.
 
 ### Two modes: resolved tree and unresolved tree
 
-MrAnderson has **two modes**. It can either work on an **unresolved** dependency **tree** and create a deeply nested directory structure for the unresolved tree based on the marked dependencies or only shadow a list of dependencies based on a **resolved dependency** tree of the same dependencies. The latter is the default.
+**Which one do you want?** Almost certainly the default, **resolved tree**. Reach for **unresolved tree** only when two of your dependencies need genuinely incompatible versions of a third one, since that's the conflict resolution can't paper over. The rest of this section explains the difference.
 
-In **unresolved tree** mode the same library -- even the same version of the library -- can occur multiple times in the unresolved dependency tree. When processing the tree MrAnderson walks it in a depth first order and creates a deeply nested directory structure and prefixes the namespaces and the references to them according to this directory structure.
+MrAnderson has **two modes**. In **resolved tree** mode (the default) it shadows a flat, conflict-resolved list of dependencies. In **unresolved tree** mode it works on the full, unresolved tree and builds a deeply nested directory structure from the marked dependencies.
+
+In **unresolved tree** mode the same library (even the same version of the library) can occur multiple times in the unresolved dependency tree. When processing the tree MrAnderson walks it in a depth first order and creates a deeply nested directory structure and prefixes the namespaces and the references to them according to this directory structure.
 
 Let's see [cider-nrepl](https://github.com/clojure-emacs/cider-nrepl)'s list of dependencies in the project file (as it is at the time of writing this README):
 
@@ -159,6 +178,8 @@ An example namespace of `[org.clojure/tools.reader "0.10.0"]` dependency of `[re
 (ns ^{:mranderson/inlined true} cider.inlined-deps.cljfmt.v0v6v4.rewrite-clj.v0v6v0.toolsreader.v0v10v0.clojure.tools.reader.edn)
 ```
 
+(Versions are encoded into the path with dots replaced by `v`, so `0.10.0` becomes `v0v10v0`. Dots already mean something in a namespace, so they can't be left as-is.)
+
 and a reference to it in `cider.inlined-deps.cljfmt.v0v6v4.rewrite-clj.v0v6v0.rewrite-clj.reader` like this:
 
 ```clojure
@@ -166,7 +187,7 @@ and a reference to it in `cider.inlined-deps.cljfmt.v0v6v4.rewrite-clj.v0v6v0.re
              [edn :as edn])
 ```
 
-In the **resolved tree** mode MrAnderson flattens the resolved dependency tree out into a topoligically ordered list and processes this ordered list. While processing MrAnderson prefixes all namespaces in the dependencies and the references to them. This also means that all dependencies even transient ones are handled as first level dependencies as they can only occur once in a resolved dependency tree.
+In the **resolved tree** mode MrAnderson flattens the resolved dependency tree out into a topologically ordered list and processes this ordered list. While processing MrAnderson prefixes all namespaces in the dependencies and the references to them. This also means that all dependencies, even transitive ones, are handled as first level dependencies: Maven's conflict resolution has already pinned every coordinate to a single version, so there's exactly one rename target per namespace.
 
 And the resolved tree of the same project:
 
@@ -191,7 +212,7 @@ And the resolved tree of the same project:
  [org.clojure/tools.reader "1.2.2"]
 ```
 
-The same namespace from `tools.reader` -- note that there is only one version of it available in the dependency tree `1.2.2`:
+The same namespace from `tools.reader` (note that there is only one version of it available in the dependency tree, `1.2.2`):
 
 ```clojure
 (ns ^{:mranderson/inlined true} cider.inlined-deps.toolsreader.v1v2v2.clojure.tools.reader.edn)
@@ -204,15 +225,15 @@ and a reference to it in `cider.inlined-deps.rewrite-clj.v0v6v0.rewrite-clj.read
              [edn :as edn])
 ```
 
-In the **unresolved tree** mode the usual way of overriding dependencies, eg. putting a first level dependency in the project file with a newer version of a library does not work. Also in this mode MrAnderson applies transient dependency hygiene meaning that it does not search and replace occurrances of a transient depedency namespace in the project's own files. To work around these limitations you can create a MrAnderson specific section in the project file and define overrides as such:
+In the **unresolved tree** mode the usual way of overriding dependencies, eg. putting a first level dependency in the project file with a newer version of a library, does not work. Also in this mode MrAnderson applies transitive dependency hygiene, meaning that it does not search and replace occurrences of a transitive dependency namespace in the project's own files (your own files shouldn't be reaching into someone else's transitive dependencies in the first place). To work around these limitations you can create a MrAnderson specific section in the project file and define overrides as such:
 
 ```clojure
 :mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}
 ```
 
-Note that the key in the overrides map is a path to a dependency in the unresolved dependency tree and the value is the new depedency node.
+Note that the key in the overrides map is a path to a dependency in the unresolved dependency tree and the value is the new dependency node.
 
-In the same section you can instruct MrAnderson to expose certain transient dependencies to the project's own source files as such:
+In the same section you can instruct MrAnderson to expose certain transitive dependencies to the project's own source files as such:
 
 ```clojure
 :mranderson {:expositions [[mvxcvi/puget fipp]]}
@@ -232,7 +253,7 @@ or you can provide the same flag on the command line:
 
 The latter supersedes the former.
 
-Again: in the **resolved tree** mode no transient dependency hygiene is applied. Also the above described config options (*overrides* and *expositions*) don't take effect.
+Again: in the **resolved tree** mode no transitive dependency hygiene is applied. Also the above described config options (*overrides* and *expositions*) don't take effect.
 
 ### Further config options
 
@@ -249,12 +270,12 @@ below; see its docstring for the authoritative list.
 | watermark                | :mranderson/inlined            |  MrAnderson adds `watermark` as metadata to inlined namespaces. This allows tools like [cljdoc](https://cljdoc.org) to exclude inlined namespaces from a library's documented API. Cljdoc, for example, automatically excludes namespaces with any of `:mranderson/inlined`, `:no-doc`, `:skip-wiki` metadata. | `:mranderson {:watermark nil}` to switch off watermarking or provide your own keyword        |
 | unresolved-tree          | false                          |  Switch between **unresolved tree** and **resolved tree** mode | `lein inline-deps :unresolved-tree true` |
 | overrides                | empty list                     |  Defines dependency overrides in **unresolved tree** mode | `:mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}` |
-| expositions              | empty list                     |  Makes transient dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
+| expositions              | empty list                     |  Makes transitive dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
 | included-source-paths    | nil                            |  (Leiningen task only.) Determines which of the provided `:source-paths` (not `:test-paths`!) will be inlined. If `nil` or `:first`, the first source path (typically `"src"`) will be the only one to be processed. If set to `:source-paths`, all `:source-paths` will be processed. If set to a vector, that vector will be interpreted as the list of source dirs to be processed, as-is, ignoring the project's `:source-paths` value. |
 
 ## Prerequisites
 
-Leiningen 2.9.1 or above. For MrAnderson to work, does not mean your project is restricted to a java or clojure version.
+Leiningen 2.9.1 or newer. MrAnderson itself needs that, but it doesn't constrain your project to any particular Java or Clojure version.
 
 ### Supported OSes and platforms
 
@@ -266,35 +287,27 @@ MrAnderson is tested and supported on Linux and macOS. Windows systems are not s
 - [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl)
 - [re-frame-10x](https://github.com/Day8/re-frame-10x)
 - [iced-nrepl](https://github.com/liquidz/iced-nrepl)
-- [conjure](https://github.com/Olical/conjure) via [conjure-deps](https://github.com/Olical/conjure-deps) -- uses MrAnderson directly, not as a `leiningen` plugin
+- [conjure](https://github.com/Olical/conjure) via [conjure-deps](https://github.com/Olical/conjure-deps) (uses MrAnderson directly, not as a Leiningen plugin)
 
 ## Development
 
-MrAnderson is a bit unusual to build because it inlines its own dependencies
-using itself, so it depends on itself as a Leiningen plugin. The `Makefile`
-wraps the moving parts:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide (setup, tests, linting,
+CI, conventions) and [doc/design.md](doc/design.md) for how the engine works.
 
-- `make test` runs the unit tests.
-- `make integration-test` runs the integration tests (against `cider-nrepl` and
-  `refactor-nrepl`, see `scripts/integration_test.sh`).
-- `make bootstrap-install` installs MrAnderson to your local maven repository
-  *without* inlining, which is needed to satisfy the self-dependency on the
-  plugin.
-- `make inline` bootstraps and then produces an inlined build under
-  `target/srcdeps`.
-- `make install` installs an inlined MrAnderson to your local maven repository,
-  so other projects on your machine can depend on it.
-- `make deploy` deploys an inlined release to Clojars.
+MrAnderson is a little unusual to build: it inlines its own dependencies using
+itself, so it depends on itself as a Leiningen plugin. The `Makefile` wraps that
+bootstrap. See [CONTRIBUTING.md](CONTRIBUTING.md) for the targets and the full
+workflow, and [doc/design.md](doc/design.md) for how the engine works.
 
 ## Related project
 
-A really nice wrapper of mranderson can be found [here](https://github.com/xsc/lein-isolate).
+A friendly Leiningen wrapper around MrAnderson lives at [lein-isolate](https://github.com/xsc/lein-isolate).
 
 ## Credits
 
 - The engine of namespace renaming/moving `mranderson.move` although heavily modified now is based on Stuart Sierra's `clojure.tools.namespace.move` namespace from [tools.namespace](https://github.com/clojure/tools.namespace).
-- Some ideas around namespace renaming/moving was borrowed from @expez my co-maintainer for [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) in their fabolous work of `rename-file-or-dir` feature.
-- @cichli did a round of profiling and perfromance/parallelisation fixes on mranderson which I took insipiration from
+- Some ideas around namespace renaming/moving were borrowed from @expez, my co-maintainer for [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl), in their fabulous work on the `rename-file-or-dir` feature.
+- @cichli did a round of profiling and performance/parallelisation fixes on mranderson which I took inspiration from
 - Had amazing feedback, conversations around MrAnderson and dependencies with @bbatsov (MrAnderson's main client), @reborg, @SevereOverfl0w, @andrewmcveigh. Really grateful for the community and these nice people in particular.
 
 ## License

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,7 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Why MrAnderson exists" {:file "doc/rationale.md"}]
+  ["How MrAnderson works" {:file "doc/design.md"}]
+  ["Glossary" {:file "doc/glossary.md"}]
+  ["Contributing" {:file "CONTRIBUTING.md"}]
+  ["Changelog" {:file "CHANGELOG.md"}]]}

--- a/doc/design.md
+++ b/doc/design.md
@@ -1,0 +1,279 @@
+# How MrAnderson works
+
+This is the guided tour of the internals: what happens when you run `lein
+inline-deps`, why it's built the way it is, and where to look in the code. If you
+just want to *use* MrAnderson, the [README](../README.md) is the place to start.
+If you're about to change the engine, read this first.
+
+## The one-sentence version
+
+MrAnderson takes a set of dependencies, copies their source under a prefix
+unique to your project, rewrites every namespace and every reference to it so the
+copies can't collide with anyone else's, repackages any bundled Java `.class`
+files the same way, and drops the result in `target/srcdeps`.
+
+The trick that makes it more than a glorified search-and-replace: Clojure
+resolves namespaces by *name* at runtime, not by file path, so a library can't
+just rename files on disk and call it done. Every place a name is written down
+has to move with it, and there are more of those than you'd think: `ns` forms,
+`require`s, fully-qualified symbols, `(load "...")` resource paths, and (for the
+Java classes a dependency might bundle, a separate resolution mechanism)
+`import`s and type hints. Getting that right across real-world code (reader
+conditionals, dashes that become underscores in Java packages, deftype classes,
+resource paths) is most of what the code is about.
+
+It also has a hard limit worth stating up front: this is a *textual* rewrite, so
+it can only move names it can see. A namespace named by a runtime-computed string
+(`(require (symbol (str "foo." x)))`, `resolve`/`find-ns` on a built-up name, a
+name read out of an EDN resource) is invisible to it. Most code doesn't do that.
+Code that does will not inline cleanly, and the [rationale](rationale.md#when-not-to-use-it)
+spells out the other sharp edges.
+
+## The pipeline
+
+The entry point is `mranderson.core/mranderson`. Everything else hangs off it. At
+a high level:
+
+```
+dependencies
+   │  resolve  (mranderson.dependency.resolver, via pomegranate/aether)
+   ▼
+resolved tree  ──expand──►  unresolved tree
+   │                              │
+   │  (resolved-tree mode)        │  (unresolved-tree mode)
+   ▼                              ▼
+unzip each artifact into target/srcdeps
+   │
+   ▼
+move namespaces + rewrite references   (mranderson.move)
+   │
+   ▼
+repackage bundled Java .class files    (jarjar, mranderson.util)
+   │
+   ▼
+target/srcdeps  +  the project's own (rewritten) sources
+```
+
+### 1. Resolve
+
+`mranderson.dependency.resolver` wraps [pomegranate](https://github.com/clj-commons/pomegranate)/aether.
+`resolve-source-deps` gives you the *resolved* tree (Maven's conflict resolution
+has already run, so every coordinate is pinned to a single version, even if it
+still shows up in more than one branch). `expand-dep-hierarchy` re-expands it into
+the *unresolved* tree, where the same library, even the same version, can appear
+in many places with different versions side by side. Those two trees feed the two modes below.
+
+`mranderson.dependency.tree` is the toolbox for walking these trees:
+`walk-deps` (depth-first visit), `walk-dep-tree` (pre/post-order with paths
+threaded down, used by unresolved mode), `walk-ordered-deps` (a flat,
+topologically ordered walk used by resolved mode), `topological-order`, and
+`evict-subtrees` (used to drop Clojure itself and a couple of other "this is part
+of the platform, don't inline it" roots).
+
+### 2. Unzip
+
+Each artifact's jar is unzipped into `target/srcdeps`. `remove-invalid-duplicates!`
+(see [#44](https://github.com/benedekfazekas/mranderson/issues/44)) deals with
+libraries that ship the same namespace in two places (riddley is the classic),
+which would otherwise confuse the file-moving step.
+
+### 3. Move namespaces and rewrite references
+
+This is the heart of it, and it has its own section below.
+
+### 4. Repackage Java classes
+
+If the dependencies bundle compiled `.class` files (http-kit, diffutils,
+claypoole, and friends), renaming Clojure namespaces isn't enough: the classes
+themselves live in packages that could collide too. MrAnderson hands those to
+[Jar Jar Links](https://github.com/pantsbuild/jarjar) (vendored under
+`java-src/mranderson/util/`), which relocates them under a prefix derived from
+your project's name and version (`clean-name-version`, e.g. `myproj010`). The
+source references to those classes are rewritten to match in `prefix-java-imports!`.
+
+One subtlety bit users for years: the Java repackaging prefix (from name+version)
+is *not* the same as the namespace prefix (`:project-prefix`). A reference to a bundled Java class therefore has to end up
+under the jarjar prefix, while the Clojure namespaces around it end up under the
+namespace prefix. See "The Java/namespace overlap" below.
+
+## The two modes
+
+MrAnderson has two ways of laying out the inlined tree, and they exist for
+genuinely different problems.
+
+### Resolved-tree mode (the default)
+
+Maven's resolution has already collapsed the tree, so each dependency appears
+exactly once. MrAnderson flattens it into a topologically ordered list and gives
+every namespace a single new home:
+
+```
+cider.inlined-deps.toolsreader.v1v2v2.clojure.tools.reader.edn
+```
+
+Because the old-name-to-new-name mapping is one-to-one and global, the reference
+rewriting is conceptually simple: build one big rename map and apply it
+everywhere. (This is exactly what the engine does now, and it's why resolved mode
+got dramatically faster. See "The rewriting engine".)
+
+The list is still produced in topological order, but with the one-pass global
+rename map that ordering no longer matters for correctness, the way it did in the
+old per-namespace design where a dependency had to be processed before the things
+that referenced it. It's effectively vestigial for resolved mode now; don't read
+load-bearing meaning into it.
+
+### Unresolved-tree mode
+
+Here MrAnderson works on the *un*resolved tree, where the same library can appear
+many times, and nests each dependency under its parent:
+
+```
+cider.inlined-deps.cljfmt.v0v6v4.rewrite-clj.v0v6v0.toolsreader.v0v10v0.clojure.tools.reader.edn
+```
+
+Every subtree is fully isolated, so two dependencies that each need a different
+(conflicting) version of a third library can both have their own copy. This is
+the mode you reach for when you have a real diamond conflict that resolution
+can't paper over.
+
+It buys that isolation with a real trade-off: the two copies are now *different
+classes*. If dependency A and dependency B both expose, say, a `fipp` record
+across their public API, and you've inlined two separate `fipp`s, an instance
+from A's copy is not an instance of B's copy and they won't interoperate.
+Nesting trades a version conflict for type-identity fragmentation, which is fine
+when the conflicting library is an internal detail of each subtree and a problem
+when it leaks across boundaries.
+
+The cost is that the rename is *path-dependent*: the same source namespace maps
+to different new names depending on which subtree it's in. So unresolved mode
+can't use the global one-to-one map; it rewrites references per subtree as it
+walks. Two extra knobs exist only here:
+
+- **overrides** force a particular version at a particular path in the tree
+  (normal "put a newer version at the top level" tricks don't work when the tree
+  is unresolved).
+- **expositions** opt a transitive dependency back into the project's own source
+  rewriting. By default unresolved mode applies *transitive dependency hygiene*:
+  it does not rewrite references to a transitive dependency in your own files,
+  because your files shouldn't be reaching into someone else's transitive deps.
+
+## The rewriting engine (`mranderson.move`)
+
+`mranderson.move` started life as a copy of Stuart Sierra's
+`clojure.tools.namespace.move` and has since grown well past it. Renaming a
+namespace means rewriting two very different kinds of text, so the engine splits
+every file into its `ns` form and its body and treats them separately.
+
+### The ns form: structural
+
+The `ns` form is parsed with [rewrite-clj](https://github.com/clj-commons/rewrite-clj)
+and edited as a zipper. This is where the namespace gets its new name (and its
+`^{:mranderson/inlined true}` watermark), and where `:require`/`:use`/`:import`
+specs get rewritten. Doing this structurally matters because `ns` forms are
+fiddly: metadata maps, prefix lists, reader conditionals for `.cljc`, and so on.
+The platform-aware handling (`find-and-replace-platform-specific-subforms`) is
+what lets a `.cljc` file that requires the same namespace under both `:clj` and
+`:cljs` branches get each branch rewritten to the right place.
+
+### The body: textual
+
+The rest of the file is rewritten as text, with a regex that finds candidate
+symbols and a replacement function (`source-replacement`) that decides what each
+one should become. Text, not structure, because the body can contain anything,
+and we only care about a narrow set of tokens: references to a moved namespace, a
+fully-qualified class under one, a type hint, or a `(load "...")` resource path.
+`source-replacement` has a branch per shape, and the comments there carry the
+scars of specific bugs (dashes versus underscores in Java packages,
+[#73](https://github.com/benedekfazekas/mranderson/issues/73); `load` paths,
+[#61](https://github.com/benedekfazekas/mranderson/issues/61)).
+
+The flip side of "it's just text" is the limit from the top of this doc: the
+regex sees literal tokens, and nothing else. A namespace named by a runtime
+string, built up and handed to `require`/`resolve`, or `read` out of a resource,
+goes straight through untouched. That's not a bug to fix so much as the boundary
+of the approach.
+
+### One pass per file
+
+In resolved mode every file is rewritten in a single pass: parse the `ns` form
+once, scan the body once, and apply *all* the renames together
+(`replace-ns-symbols`). Tokens are dispatched to the matching rename by their
+first segment, so a file full of `clojure.core` calls and locals costs almost
+nothing. This replaced an older design that re-scanned and re-parsed every file
+once per moved namespace, which on a medium dependency tree meant parsing each
+file around a dozen times. If you're tempted to "simplify" this back into a loop
+over namespaces, run `lein test :benchmark` first and watch it get slow again.
+
+### The Java/namespace overlap
+
+The nastiest corner, and the source of a family of `ClassNotFoundException` bugs
+([#33](https://github.com/benedekfazekas/mranderson/issues/33),
+[#97](https://github.com/benedekfazekas/mranderson/issues/97)), is when a package
+is *both* a Java package (it has `.class` files) and a Clojure namespace (it has
+a `.clj` file). claypoole's `com.climate.claypoole.impl` is the textbook case.
+That one package holds both:
+
+- `PriorityThreadpoolImpl`, a compiled Java `.class`, and
+- `PriorityThreadpool`, a deftype from the Clojure namespace of the same name.
+
+The main namespace imports both.
+
+These have to end up in different places: the Java class follows jarjar to the
+name+version prefix, the deftype follows its namespace to the `:project-prefix`.
+The engine keeps them straight by knowing which fully-qualified names correspond
+to actual `.class` files:
+
+- A mixed `(:import [pkg DeftypeClass JavaClass])` is *split* so each class gets
+  the right package (`rewrite-import-spec`), and the match is done as a suffix so
+  it still works after the namespace move has already prefixed the shared package.
+- A fully-qualified Java class reference in a body (`(some.pkg.Widget. ...)`) is
+  left untouched by the namespace move and prefixed by the Java pass instead,
+  because the namespace move would otherwise send it to the wrong prefix.
+
+In MrAnderson's source-rewrite model the inlined deftype/defrecord classes are
+generated when the inlined source is compiled, so there's no bundled `.class` to
+relocate and they move with their namespace. (A dependency that ships its own
+AOT-compiled classes is just the bundled-`.class` case above: those go through
+jarjar like any other Java class.)
+
+## Watermarking
+
+Every inlined namespace gets `^{:mranderson/inlined true}` metadata. This is how
+downstream tools (cljdoc, for one) tell "this is a vendored copy, don't document
+it" from the library's real API. The key is configurable via the `watermark`
+option; set it to `nil` to turn it off.
+
+## The Leiningen layer
+
+Two thin namespaces wrap the engine for Leiningen users:
+
+- `leiningen.inline-deps` is the `lein inline-deps` task. It reads options off
+  the CLI and the project map and calls into `mranderson.core`.
+- `mranderson.plugin` is Leiningen middleware that injects the
+  `plugin.mranderson/config` profile (defined as data in `mranderson.profiles`),
+  which is what puts `target/srcdeps` on the classpath so you can `repl`/`test`/
+  `install` against the inlined build.
+
+None of this is required. `mranderson.core/inline-deps` is a plain data-in entry
+point that does the same work without Leiningen, which is what tools.build and
+Clojure CLI users call.
+
+## A note on self-hosting
+
+MrAnderson inlines its *own* dependencies (pomegranate, tools.namespace, fs,
+rewrite-clj) using itself. That makes the build a small bootstrap puzzle, which
+the `Makefile` handles. See [CONTRIBUTING](../CONTRIBUTING.md) for the details.
+It also means MrAnderson is its own best integration test: if a change breaks the
+engine, `make install` tends to fall over.
+
+## Where to look
+
+| You want to change...                         | Start in |
+|-----------------------------------------------|----------|
+| The pipeline / orchestration                  | `mranderson.core` |
+| Namespace and reference rewriting             | `mranderson.move` |
+| Java class repackaging / jarjar               | `mranderson.util`, `java-src/mranderson/util/` |
+| Dependency resolution                         | `mranderson.dependency.resolver` |
+| Tree walking and ordering                     | `mranderson.dependency.tree` |
+| The `lein inline-deps` task / options         | `leiningen.inline-deps`, `mranderson.plugin` |
+| Performance                                   | `mranderson.benchmark` (run with `lein test :benchmark`) |

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,0 +1,106 @@
+# Glossary
+
+MrAnderson sits at the bottom of the JVM/Clojure stack, so its docs lean on a
+fair amount of ecosystem vocabulary. If you're new to Clojure or the JVM, here's
+the jargon in plain English. Terms are roughly ordered from "you need this to
+understand the README" to "you need this to hack on the internals."
+
+**Classpath.** The single global list of all the compiled code available to a
+running JVM program. Think Python's `sys.path`, with one crucial difference:
+there's room for only *one* version of any given class. That one-version rule is
+the whole reason MrAnderson exists.
+
+**Dependency / transitive dependency.** A library your project pulls in is a
+dependency. A *transitive* dependency is a dependency of a dependency, something
+you didn't ask for directly but that got pulled in because something you do use
+needs it.
+
+**Diamond dependency / diamond conflict.** When two of your dependencies both
+depend on a third one, but need *incompatible* versions of it. Drawn out, the
+graph looks like a diamond (you at the top, the shared library at the bottom).
+Because the classpath holds one version per class, this is the conflict that
+nothing short of inlining can fully resolve.
+
+**Inlining / shading / vendoring.** Three names for the same technique: copy a
+dependency's code into your own project under a private name, rewrite every
+reference to it, and ship that copy. Your private copy can't collide with anyone
+else's version. This is what MrAnderson does. (The Java world usually says
+"shading"; "vendoring" is common elsewhere; MrAnderson's command is
+`inline-deps`, so these docs lead with "inlining.")
+
+**`:exclusions`.** A build-tool feature that tells the dependency resolver to
+drop a particular transitive dependency. The first thing to try when you have a
+conflict; inlining is what you reach for when exclusions aren't enough.
+
+**Namespace.** Clojure's unit of code organization, roughly a module. The
+important part for MrAnderson: a namespace is identified by its *name* (like
+`clojure.string`), and Clojure resolves that name at runtime, not by file path.
+So renaming a namespace means changing the name everywhere it's written, not just
+moving a file.
+
+**`ns` form / `require` / `:import` / `:use`.** The `ns` form is the declaration
+at the top of a Clojure file that names the namespace and lists what it pulls in
+(its `require`s for other Clojure namespaces, its `:import`s for Java classes).
+These are the references MrAnderson has to rewrite.
+
+**Leiningen (`lein`, `project.clj`).** The long-standing Clojure build tool.
+`project.clj` is its config file (think `package.json`). MrAnderson ships as a
+Leiningen plugin.
+
+**tools.deps / Clojure CLI (`deps.edn`, tools.build).** The other common Clojure
+build toolchain, an alternative to Leiningen, not a layer on top of it.
+`deps.edn` is its config file. MrAnderson's `inline-deps` function works here
+without Leiningen.
+
+**jar / uberjar.** A jar is a zip of compiled JVM code, the unit you publish and
+depend on (a library is distributed as a jar). An *uberjar* (or "fat jar") bundles
+your app and *all* its dependencies into one runnable jar. Uberjar tools can shade
+dependencies at assembly time, but that's for applications; MrAnderson is for
+libraries that ship a normal jar with some dependencies quietly inlined.
+
+**Maven / aether / pomegranate / Clojars.** Maven is the JVM's dependency and
+artifact system (it resolves versions and downloads jars). aether is the library
+that talks to Maven repositories; pomegranate is the Clojure wrapper MrAnderson
+uses for resolution. Clojars is the community package registry for Clojure (like
+PyPI or npm).
+
+**Conflict resolution.** The step where Maven, given a dependency graph that asks
+for several versions of the same library, picks one. The *resolved* tree is the
+result; the *unresolved* tree is the original graph before that collapse.
+
+**REPL / nREPL / middleware.** A REPL is an interactive Clojure prompt. nREPL is
+the networked server behind editor integrations (the thing your editor talks to).
+*Middleware* plugs into nREPL to add features, and it gets loaded into the
+*user's* running process, alongside the user's own dependencies, which is exactly
+why a tool that drags in conflicting versions is such a problem. cider-nrepl and
+refactor-nrepl are nREPL middleware, and MrAnderson's main clients.
+
+**AOT (ahead-of-time compilation).** Compiling Clojure source to JVM `.class`
+files before running, instead of at load time. AOT interacts badly with inlining
+in a couple of ways; see [when not to use it](rationale.md#when-not-to-use-it).
+
+**deftype / defrecord.** Clojure forms that generate a Java class from Clojure
+code. Relevant because a `deftype` class is created when the source compiles, so
+(unlike a bundled Java `.class`) it has no separate file to relocate and moves
+with its namespace.
+
+**Reader conditionals / `.cljc`.** A `.cljc` file runs on both Clojure (JVM) and
+ClojureScript. Reader conditionals (`#?(:clj ... :cljs ...)`) select different
+code per platform. MrAnderson has to rewrite each branch to the right place.
+
+**Type hint.** An annotation like `^String` that tells the compiler a value's
+Java type, so it can avoid *reflection* (looking the type up at runtime, which is
+slow). Clojure emits a warning when it has to use reflection; this project's CI
+treats that warning as an error.
+
+**Topological order.** An ordering of a dependency graph where each item comes
+before the things that depend on it. MrAnderson builds one when flattening the
+resolved tree.
+
+**jarjar (Jar Jar Links).** A tool that relocates Java classes inside a jar under
+a new package name. MrAnderson uses it for the `.class` files a dependency
+bundles, while doing the Clojure side as a source rewrite.
+
+**Watermark.** The `^{:mranderson/inlined true}` metadata MrAnderson stamps on
+every inlined namespace, so tools like cljdoc can tell a vendored copy from the
+library's real API.

--- a/doc/rationale.md
+++ b/doc/rationale.md
@@ -1,0 +1,113 @@
+# Why MrAnderson exists
+
+## The problem
+
+The JVM has one classpath and one version of every class on it. Clojure inherits
+that. If your project pulls in library A, which needs `some.lib 1.0`, and library
+B, which needs `some.lib 2.0`, and those two versions aren't compatible, you have
+a problem that no amount of `:exclusions` will fully solve. Maven's conflict
+resolution will pick one version and hope for the best. Sometimes that's fine.
+Sometimes you get a `NoSuchMethodError` at three in the morning.
+
+For *applications* this is usually annoying but manageable: you control the whole
+dependency set, so you can pin versions and exclude things until it works. For
+*libraries* it's worse, because your dependencies leak onto your users. If you
+write a library that depends on `some.lib 1.0`, every project that uses your
+library now has an opinion about `some.lib` forced on it, and if the user needs
+`2.0`, you've just started a fight.
+
+This is especially painful for developer tooling. nREPL middleware (cider-nrepl,
+refactor-nrepl) gets loaded into *someone else's* running process, alongside
+*their* dependencies. A REPL tool that drags in its own `tools.reader` or
+`rewrite-clj` and clobbers the user's version is a tool that breaks the user's
+project. That's the itch MrAnderson was built to scratch, and cider-nrepl has
+been its main client for years.
+
+## The fix: inline and shadow
+
+The way out is *inlining* (also called shading or vendoring): take the
+dependency, copy it into your own project under a private name, rewrite every
+reference, and ship that. Now your copy of `some.lib` is called something like
+`yourproject.inlined-deps.some.lib`, it can't collide with anyone else's
+`some.lib`, and your users never even know it's there.
+
+The catch in Clojure specifically is that namespaces are resolved by *name* at
+runtime, not by file path. You can't just move files and rename packages the way
+a Java bytecode shader does. You have to rewrite the names inside the source: the
+`ns` forms, the `require`s, the `import`s, the type hints, the fully-qualified
+symbols, the `(load ...)` paths. And if the dependency also bundles Java
+`.class` files, you have to relocate those too, with a separate tool, and make
+the rewritten source agree with where they landed. MrAnderson does all of that.
+The [design doc](design.md) walks through how.
+
+## What about the alternatives?
+
+MrAnderson occupies a specific niche, source-level inlining for libraries, and
+most of the obvious alternatives are solving a different problem.
+
+### Just use `:exclusions` and pin versions
+
+This is the right answer most of the time, and you should try it first. It breaks
+down only when you have a genuine diamond conflict: two dependencies that need
+*incompatible* versions of a third, where no single version satisfies both. Then
+no exclusion helps, because there's no good version to keep. That's the point
+where inlining earns its keep.
+
+### Uberjar shading (depstar, tools.build `uber`, Maven Shade Plugin)
+
+These relocate packages when you build an **application** uberjar. They run at
+assembly time, operate on bytecode/jar contents, and produce a single fat jar
+with the conflicts shaded away. Great for apps. They don't help a **library**
+that wants to publish a normal jar with a few dependencies quietly inlined,
+because there's no uberjar in the picture: you're deploying a library artifact
+that other people will pull in as a dependency. MrAnderson produces inlined
+*source* that goes into your ordinary library jar.
+
+There's also the Clojure-runtime wrinkle: bytecode relocation can rename compiled
+class names, but Clojure resolves namespaces from *strings* at runtime, and those
+strings aren't reliably where a bytecode shader looks. So a pure jarjar/shade
+pass tends to leave the namespace references behind, which is brittle at best.
+MrAnderson uses jarjar for the Java `.class` files but does the Clojure side as a
+source rewrite.
+
+### shadow-cljs
+
+Unrelated, despite the name. shadow-cljs is a ClojureScript build tool; the
+"shadow" isn't about shading dependencies.
+
+### lein-isolate
+
+A friendly Leiningen wrapper around MrAnderson itself. If you're on Leiningen and
+want a gentler interface, [lein-isolate](https://github.com/xsc/lein-isolate)
+wraps it nicely.
+
+## When *not* to use it
+
+Honest version: inlining is a power tool, and it has sharp edges.
+
+- **If plain `:exclusions` work, use those.** Inlining is more machinery and more
+  ways to go wrong.
+- **The inlined namespaces are ugly** (`yourproj.inlined-deps.foo.v1v2v3.foo.core`)
+  and they show up in stack traces. That's the price of isolation.
+- **It's a textual rewrite, so it can't follow indirection.** A namespace named
+  by a runtime-computed string, `(require (symbol ...))`, `resolve`/`find-ns` on
+  a built-up name, or a name read out of a resource file, is invisible to the
+  rewriter. The reference stays pointed at the original, un-inlined name and blows
+  up at runtime.
+- **AOT and macros are the classic trap.** If you ahead-of-time compile and a
+  macro from an inlined dependency expands to a fully-qualified symbol that the
+  rewriter didn't catch (syntax-quoted symbols are the usual culprit), you get a
+  `ClassNotFoundException` no test saw coming. `:gen-class` with a fixed `:name`
+  has the same flavour: the generated class name is a config string, not a
+  namespace reference, so it won't be prefixed.
+- **Unresolved-tree mode trades version conflicts for type-identity
+  fragmentation.** Two inlined copies of the same library are two different sets
+  of classes; instances from one are not instances of the other. Fine when the
+  conflicting library is each subtree's private business, a problem when it shows
+  up in a public API.
+- **It's tested and supported on Linux and macOS, not Windows.**
+
+None of this is exotic, but it's the stuff that bites. Most code inlines cleanly.
+If you've read all that and you still have two libraries fighting over a third,
+or you're shipping tooling that has to coexist with whatever the user already
+has on their classpath, MrAnderson is for you.


### PR DESCRIPTION
The project had a single README. This fills out the docs so they're useful to humans and agents alike.

New:
- **doc/design.md** - how the engine works: the resolve → unzip → namespace-rewrite → jarjar pipeline, resolved vs unresolved tree mode, the rewriting engine (structural ns-form + textual body, the single-pass), the Java/namespace overlap that caused the #33/#97 family of bugs, watermarking, and a "where to look" table. The doc I wish I'd had before touching `mranderson.move`.
- **doc/rationale.md** - why it exists (JVM/Clojure dependency conflicts, especially for nREPL-style tooling that loads into someone else's process), an honest comparison to the alternatives (`:exclusions`, uberjar shading like depstar/tools.build/maven-shade, lein-isolate), and a frank "when not to use it".
- **CONTRIBUTING.md** - the self-hosting bootstrap, running tests, the eastwood-lints-tests-and-fails-on-reflection gotcha, the benchmark, the CI layout, and conventions.
- **AGENTS.md** - a terse repo map + gotchas for coding agents.
- **doc/cljdoc.edn** wires the articles into cljdoc; a PR template.

README: added a Documentation section linking the above, and fixed the `--` dashes GitHub doesn't render plus a few typos.

Docs only, no code. Written in plain prose, grounded in the actual code.