### PR TITLE
Audit and backfill ns/var docstrings and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- Only add a namespace to `:aot` (Leiningen plugin) when its `ns` form actually has a `:gen-class` clause, not when `:gen-class` merely appears as text in a docstring or comment
 - Leave a fully-qualified reference to a repackaged Java class (e.g. `(some.pkg.Widget. ...)`) untouched during the namespace move when its package is also a moved namespace, so the java-import pass can point it at the jarjar-repackaged class instead of the namespace prefix (otherwise it threw `ClassNotFoundException` at runtime). Deftype/defrecord classes, which have no `.class` file, still move with their namespace
 - [#33](https://github.com/benedekfazekas/mranderson/issues/33) Split a mixed `(:import ...)` correctly when a deftype class and a repackaged Java class share a package (e.g. claypoole): the Java class now points at its jarjar package even though the namespace move has already prefixed the shared package
 - [#97](https://github.com/benedekfazekas/mranderson/issues/97) Prefix repackaged Java classes referenced in a namespace body even when the file has no `(:import ...)` form (previously such references were left bare and threw `ClassNotFoundException` at runtime)

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -1,4 +1,7 @@
 (ns leiningen.inline-deps
+  "The `lein inline-deps` task: reads MrAnderson options off the CLI and the
+  project map and calls into `mranderson.core`. Just a Leiningen wrapper; the
+  engine runs fine without it via `mranderson.core/inline-deps`."
   (:require [clojure.edn :as edn]
             [me.raynes.fs :as fs]
             [mranderson.core :as c]
@@ -7,6 +10,10 @@
   (:import [java.util UUID]))
 
 (defn- lookup-opt
+  "Resolves option `opt-key` with precedence: CLI args > project `:mranderson`
+  map > `not-found`. `cli-opts` is the parsed CLI arg sequence (`:key val ...`);
+  the value is the element following `opt-key`. `project-opts` is the project
+  map's `:mranderson` section."
   ([opt-key cli-opts project-opts]
    (lookup-opt opt-key cli-opts project-opts nil))
 
@@ -33,6 +40,13 @@
     (log/warn "WARNING: `:aot` is set in this project. Inlining AOT-compiled namespaces is known to produce broken prefixes (see https://github.com/benedekfazekas/mranderson/issues/89). Consider disabling `:aot` while inlining dependencies.")))
 
 (defn- lein-project->ctx
+  "Builds the engine `ctx` map from a Leiningen `project` and the raw CLI `args`.
+  Parses `args` as EDN, resolves each option via `lookup-opt` (CLI > project
+  `:mranderson` > default), and maps Leiningen-facing names onto the engine's:
+  e.g. `:project-prefix` -> `:pprefix` (defaulting to a random prefix) and
+  `:skip-javaclass-repackage` -> `:skip-repackage-java-classes`. Also derives the
+  `target-path`-relative `srcdeps` directory. See `mranderson.core/mranderson`
+  for the `ctx` keys."
   [{:keys [root target-path name version mranderson]} args]
   (let [cli-opts                    (map edn/read-string args)
         project-prefix              (some-> (lookup-opt :project-prefix cli-opts mranderson
@@ -65,12 +79,18 @@
 (defn inline-deps
   "Inline and shadow dependencies so they can not interfere with other libraries' dependencies.
 
+  Options may be given on the command line (`:key val`) or under `:mranderson`
+  in the project map; the command line wins.
+
   Available options:
 
-  :project-prefix           string    Project prefix to use when shadowing
+  :project-prefix           string    Project prefix to use when shadowing (default: mranderson{rnd})
   :skip-javaclass-repackage boolean   If true Jar Jar Links won't be used to repackage java classes
   :prefix-exclusions        list      List of prefixes that should not be processed in imports
-  :unresolved-tree          boolean   Enforces unresolved tree mode"
+  :unresolved-tree          boolean   Enforces unresolved tree mode
+  :overrides                map       Dependency overrides, unresolved-tree mode only
+  :expositions              list      Transitive deps exposed to the project's own sources, unresolved-tree mode only
+  :watermark                keyword   Metadata key added to inlined namespaces (default: :mranderson/inlined; nil to disable)"
   [{:keys [repositories dependencies target-path] :as project} & args]
   (warn-on-aot project)
   (c/copy-source-files (u/determine-source-dirs project) target-path)

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -1,4 +1,10 @@
 (ns mranderson.core
+  "Orchestrates the dependency-inlining pipeline: resolve dependencies, unzip
+  each artifact under `target/srcdeps`, move and rewrite the namespaces (via
+  `mranderson.move`), and repackage any bundled Java `.class` files through
+  jarjar. `inline-deps` is the Leiningen-free entry point; `mranderson` is the
+  lower-level workhorse it and the Leiningen task both call into. See
+  doc/design.md for the architecture."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -23,7 +29,9 @@
     (fs/file target-dir entry-path)))
 
 (defn- unzip
-  "Takes the path to a zipfile source and unzips it to target-dir."
+  "Unzips the jar/zip at `source` into `target-dir` (defaults to `(name
+  source)`), skipping `META-INF` and `clj-kondo.exports` entries. Returns the
+  seq of unzipped Clojure source entry names (`.clj`/`.cljc`/`.cljs`)."
   ([source]
    (unzip source (name source)))
   ([source target-dir]
@@ -47,7 +55,12 @@
            (conj! clj-files entry-name)))
        (persistent! clj-files)))))
 
-(defn- replacement-prefix [pprefix src-path art-name art-version underscorize?]
+(defn- replacement-prefix
+  "Builds the dotted namespace prefix an artifact's namespaces move under:
+  `pprefix`, then the portion of `src-path` below the prefix dir, then
+  `art-name` and `art-version`. When `underscorize?` is falsey, underscores are
+  turned back into dashes (namespace form rather than file-path form)."
+  [pprefix src-path art-name art-version underscorize?]
   (let [path (->> (str/split (str src-path) #"/")
                   (drop-while #(not= (-> (u/sym->file-name pprefix)
                                          (str/split #"/")
@@ -60,7 +73,10 @@
          (concat path)
          (str/join "."))))
 
-(defn- replacement [prefix postfix underscorize?]
+(defn- replacement
+  "Joins `prefix` and `postfix` into a new namespace symbol. When `underscorize?`
+  is truthy, dashes in `postfix` become underscores."
+  [prefix postfix underscorize?]
   (->> (if underscorize?
          (-> postfix
              str
@@ -85,7 +101,11 @@
   [srcdeps]
   (into #{} (map (partial u/class-file->fully-qualified-name srcdeps)) (u/class-files srcdeps)))
 
-(defn- import-fragment-left [^String clj-source]
+(defn- import-fragment-left
+  "Returns the suffix of `clj-source` starting at the `(` that opens the
+  `(:import ...)` form, or nil if there is no `:import`. The left edge from which
+  `import-fragment` slices out the whole import form."
+  [^String clj-source]
   (let [index-of-import (.indexOf clj-source ":import")]
     (when (> index-of-import -1)
       (drop (loop [ns-decl-fragment (reverse (take index-of-import clj-source))
@@ -98,7 +118,10 @@
 
                     :else (recur (rest ns-decl-fragment) (inc index-of-open-bracket)))) clj-source))))
 
-(defn- import-fragment [clj-source]
+(defn- import-fragment
+  "Extracts the full `(:import ...)` form from `clj-source` as a string by
+  balancing parentheses, or nil if there is none."
+  [clj-source]
   (let [import-fragment-left (import-fragment-left clj-source)
         frag-count (count import-fragment-left)]
     (when (and import-fragment-left (> frag-count 0))
@@ -155,7 +178,10 @@
         (and (.isDirectory f) (empty? (.listFiles f)))
         (.delete f)))))
 
-(defn- replace-class-deps! [srcdeps jar-file]
+(defn- replace-class-deps!
+  "Deletes the original `.class` files under `srcdeps` and unzips the
+  jarjar-repackaged `jar-file` in their place."
+  [srcdeps jar-file]
   (log/info "deleting class files in" (str srcdeps) "...")
   (doseq [class-dir (u/java-class-dirs srcdeps)]
     (delete-class-files! (fs/file srcdeps class-dir))
@@ -266,13 +292,12 @@
     (boolean (some #(str/includes? rel (str (u/sym->file-name %) "/")) prefix-exclusions))))
 
 (defn- prefix-java-imports!
-  "Rewrites Java `:import`s of repackaged classes across every inlined source
-  file under `srcdeps` - both the dependencies and the consuming project. The
-  per-dependency pass misses top-level dependency namespaces (#54) and the
-  project's own files (#92); this final pass, run once all the dependency class
-  files are unpacked (so the full set of repackaged classes is known), covers
-  them. It is idempotent: `rewrite-java-imports` won't re-prefix an import that
-  was already rewritten by the per-dependency pass."
+  "Rewrites Java `:import`s (and fully-qualified body references) of repackaged
+  classes across every inlined source file under `srcdeps` - both the
+  dependencies and the consuming project (#54, #92). The single Java-import pass,
+  run after the namespaces have moved but while the class files are still in
+  their original (unprefixed) locations, so their fully-qualified names are
+  known. Files under `prefix-exclusions` are skipped."
   [pname pversion srcdeps prefix-exclusions]
   (let [cleaned-name-version (u/clean-name-version pname pversion)
         class-names          (map (partial u/class-file->fully-qualified-name srcdeps) (u/class-files srcdeps))]
@@ -377,7 +402,13 @@
   [clj-files]
   (sort-by #(str/replace % ".cljc" ".cljx") clj-files))
 
-(defn- unzip-artifact! [{:keys [srcdeps]} {:keys [src-path branch]} dep]
+(defn- unzip-artifact!
+  "Unzips a single artifact's jar into `srcdeps` and returns a tuple of its
+  artifact info (cleaned name, version, clj files and dirs, dep) and the child
+  context (`src-path`, `branch`, `parent-clj-dirs`) the tree walk threads into
+  this artifact's own dependencies. The pre-fn half of the walk callback pair,
+  with `update-artifact!` as the post-fn."
+  [{:keys [srcdeps]} {:keys [src-path branch]} dep]
   (let [art-name         (-> dep first name (str/split #"/") last)
         art-name-cleaned (str/replace art-name #"[\.-_]" "")
         art-version      (str "v" (-> dep second (str/replace "." "v")))
@@ -398,6 +429,9 @@
       :parent-clj-dirs (map fs/file clj-dirs)}]))
 
 (defn copy-source-files
+  "Copies each of `source-paths` into `<target-path>/<target-suffix>`
+  (`target-suffix` defaults to `\"srcdeps\"`). Stages the project's own sources
+  alongside the inlined deps so their references can be rewritten too."
   ([source-paths target-path]
    (copy-source-files source-paths target-path "srcdeps"))
 
@@ -417,10 +451,10 @@
 (defn- mranderson-resolved-deps!
   "Unzips and transforms files in a resolved dependency tree.
 
-  Creates a topological order based on the expanded tree. Flattens out the resolved tree into a list like data structure
-  ordered by the expanded tree based topological order. Processes this ordered list with `walk-ordered-deps` that first
-  unzips all deps and collects their contextual info and then performs the source transformation in
-  reverse topological order."
+  Flattens the resolved tree into a topologically ordered list (the ordering is
+  vestigial now - see doc/design.md), unzips every artifact and moves its
+  namespaces via `walk-ordered-deps`, then applies all the collected renames in a
+  single global pass so each source file is parsed only once."
   [resolved-deps unresolved-deps paths ctx]
   (let [unresolved-deps-topo-order (t/topological-order unresolved-deps)
         topo-comparator            (fn [[l] [r]]
@@ -453,7 +487,7 @@
   - prefix-exclusions: prefixes to exclude when prefixing imports for java classes
   - unresolved-tree: switch to unresolved tree mode if true
   - overrides: overrides in the unresolved tree in unresolved tree mode
-  - expositions: transient dependencies made available for the project source files in unresolved tree mode
+  - expositions: transitive dependencies made available for the project source files in unresolved tree mode
   - watermark: meta flag to mark inlined dependencies"
 
   [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps prefix-exclusions] :as ctx} paths]
@@ -467,8 +501,8 @@
       (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))
     (when-not (or skip-repackage-java-classes (empty? (u/class-files srcdeps)))
       (let [jar-file (fs/file (fs/parent srcdeps) "class-deps.jar")]
-        ;; rewrite imports the per-dependency pass missed (top-level deps, the
-        ;; project's own files) while the class files are still in their original
+        ;; rewrite java imports across all inlined sources (deps + the project's
+        ;; own files) while the class files are still in their original
         ;; (unprefixed) locations, so their names are known
         (prefix-java-imports! pname pversion srcdeps prefix-exclusions)
         (class-deps-jar! srcdeps jar-file)

--- a/src/mranderson/dependency/resolver.clj
+++ b/src/mranderson/dependency/resolver.clj
@@ -1,17 +1,29 @@
 (ns mranderson.dependency.resolver
+  "Dependency resolution via pomegranate/aether.
+
+  `resolve-source-deps` produces the resolved tree (Maven conflict resolution has
+  run, each coordinate pinned to one version); `expand-dep-hierarchy` re-expands
+  it into the unresolved tree where the same library may appear in many branches
+  at different versions. These two trees feed the two inlining modes."
   (:require [cemerick.pomegranate.aether :as aether]
             [mranderson.dependency.tree :as t]))
 
 (defn resolve-source-deps
-  "Retrieves the given dependencies using the given `repositories`"
+  "Resolves `source-dependencies` against `repositories` and returns the resolved
+  dependency hierarchy (a nested `[name version] -> subtree` map). Maven conflict
+  resolution has already run, so each coordinate is pinned to a single version
+  even where it appears in multiple branches."
   [repositories source-dependencies]
   (->> (aether/resolve-dependencies :coordinates source-dependencies :repositories repositories)
        (aether/dependency-hierarchy source-dependencies)))
 
 (defn expand-dep-hierarchy
-  "Expands the first level of the given dep hierarchy into an unresolved dependency tree.
+  "Re-expands `dep-hierarchy` into a full unresolved dependency tree.
 
-  Understands overrides so a node can be overriden at any point of the tree while it is being built."
+  Seeds from the top-level coordinates and recursively re-resolves each node's
+  own dependencies, so the same library may appear at many paths with different
+  versions. `overrides` can force a particular version at a given path while the
+  tree is built (see `walk&expand-deps`)."
   [repositories dep-hierarchy overrides]
   (t/walk&expand-deps
    (zipmap (keys dep-hierarchy) (repeat nil))

--- a/src/mranderson/dependency/tree.clj
+++ b/src/mranderson/dependency/tree.clj
@@ -1,8 +1,16 @@
 (ns mranderson.dependency.tree
+  "Walking and ordering of dependency trees.
+
+  A dependency tree here is a nested map of `[name version] -> subtree`. This
+  namespace provides depth-first walks for both modes (`walk-dep-tree` for
+  unresolved, `walk-ordered-deps` for resolved), tree expansion
+  (`walk&expand-deps`), subtree eviction, and topological ordering."
   (:require [clojure.tools.namespace.dependency :as dep]))
 
 ;; inlined from leiningen source
 (defn walk-deps
+  "Depth-first walk of a dependency tree, calling `(f dep level)` for each node
+  (root level defaults to 0). Side-effecting; ignores `f`'s return value."
   ([deps f level]
      (doseq [[dep subdeps] deps]
        (f dep level)
@@ -11,7 +19,11 @@
   ([deps f]
    (walk-deps deps f 0)))
 
-(defn path-pred [path dep k]
+(defn path-pred
+  "True when appending `dep`'s name to `path` equals `k`, i.e. `dep` sits at path
+  `k` in the tree. Used to match overrides/expositions to a node by its full
+  path."
+  [path dep k]
   (= k (conj path (first dep))))
 
 (defn walk&expand-deps
@@ -47,7 +59,7 @@
   "Evict subtrees from a dependency tree.
 
   `subtree-roots` are defined as a set of dependency names (for example `#{'org.clojure/clojure 'org.clojure/clojurescript}`
-  without their versions. Tested on a resolved tree. Assumed that it would evict all subtrees from an unresolved depedency
+  without their versions. Tested on a resolved tree. Assumed that it would evict all subtrees from an unresolved dependency
   tree."
   [deps subtree-roots]
   (->> (map
@@ -58,11 +70,13 @@
        (into {})))
 
 (defn walk-dep-tree
-  "Walks a dependency tree in depth first order.
+  "Depth-first walk of a dependency tree (used by unresolved-tree mode),
+  side-effecting.
 
-  Applies `pre-fn` on node before going down a level. `pre-fn` calculates and returns its own context and paths,
-  these are passed down to the next level. After the subtree is processed `post-fn` gets applied using the context,
-  paths returned by `pre-fn` for the same node."
+  For each node calls `(pre-fn ctx paths dep)`, which must return
+  `[pre-result new-paths]`; `new-paths` is threaded down into the subtree. After
+  the subtree is processed, calls `(post-fn ctx pre-result paths)` with this
+  node's original `paths`. Return values are discarded."
   [deps pre-fn post-fn paths ctx]
   (doseq [[dep subdeps] deps]
     (let [[pre-result new-paths] (pre-fn ctx paths dep)]
@@ -71,11 +85,15 @@
       (post-fn ctx pre-result paths))))
 
 (defn walk-ordered-deps
-  "Walks a flat list of dependencies.
+  "Walks a flat, topologically ordered map of dependencies (used by
+  resolved-tree mode).
 
-  Applies `pre-fn` on all the dependencies and collects the `pre-fn` returned contextual values and paths.
-  Runs `post-fn` on all the dependencies in a reverse order using the `pre-fn` results and paths, and
-  returns a vector of the `post-fn` results in that order."
+  First calls `(pre-fn ctx paths dep)` for every dep, collecting their results.
+  Then calls `post-fn` for each dep in reverse order, threading into `paths` the
+  `:parent-clj-dirs` accumulated across all the pre-results, and returns a vector
+  of the `post-fn` results in that (reversed) order. Unlike `walk-dep-tree`, this
+  returns its `post-fn` results rather than discarding them - resolved mode
+  applies the collected renames in one global pass."
   [deps pre-fn post-fn paths ctx]
   (->> (keys deps)
        (map (partial pre-fn ctx paths))
@@ -84,6 +102,9 @@
           (mapv (fn [[pre-result _]] (post-fn ctx pre-result (update paths :parent-clj-dirs concat clj-dirs))) deps)))))
 
 (defn- create-dep-graph
+  "Builds a `clojure.tools.namespace.dependency` graph from a nested dep tree,
+  declaring each child a dependency of its parent. Top-level nodes are made to
+  depend on nil so isolated roots still appear in the topological sort."
   ([graph deps level]
    (reduce
     (fn [graph [dep subdeps]]
@@ -97,5 +118,8 @@
   ([deps]
    (create-dep-graph (dep/graph) deps 0)))
 
-(defn topological-order [dep-tree]
+(defn topological-order
+  "Returns a map of each dependency in `dep-tree` to its position (an integer) in
+  topological order. Used to order the resolved tree before walking it."
+  [dep-tree]
   (zipmap (dep/topo-sort (create-dep-graph dep-tree)) (range)))

--- a/src/mranderson/log.clj
+++ b/src/mranderson/log.clj
@@ -1,7 +1,7 @@
 (ns ^:no-doc mranderson.log
   "Here we replicate lein logging.
   This gives us what a lein plugin user would expect and is also reasonable for non-lein use.
-  We don't use's lein's logging methods because we don't want to tie ourselves to lein just for logging.
+  We don't use lein's logging methods because we don't want to tie ourselves to lein just for logging.
   We also add in multi-threading support which lein logging does not do.")
 
 ;; lein-isms for controlling logging

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -250,7 +250,14 @@
     (and (seq last-seg)
          (Character/isUpperCase ^char (first last-seg)))))
 
-(defn- source-replacement [old-sym new-sym match]
+(defn- source-replacement
+  "Decides what a single matched body token `match` becomes under the rename
+  `old-sym` -> `new-sym`. Handles each shape in turn: a bare namespace ref, a
+  package/underscore prefix, a `^`-prefixed type hint, a dotted namespace/class
+  reference (dashes become underscores for a class, see #73), and a
+  `(load \"...\")` slash/underscore resource path (#61). Returns `match`
+  unchanged when nothing applies."
+  [old-sym new-sym match]
   (let [old-ns-ref      (name old-sym)
         new-ns-ref      (name new-sym)
         old-ns-ref-dot  (str old-ns-ref ".")
@@ -307,14 +314,23 @@
   (when-not (#{:uneval} (z/tag node))
     (= platform (z/sexpr (z/left node)))))
 
-(defn- find-and-replace-platform-specific-subforms [platform ns-loc]
+(defn- find-and-replace-platform-specific-subforms
+  "In a `.cljc` ns form, masks the subforms belonging to `platform` (the opposite
+  platform from the one being moved) by replacing each with a `<platform>_require`
+  placeholder symbol, so the rename only touches the relevant branch. Returns
+  `[replaced-nodes ns-loc]`; pair with `restore-platform-specific-subforms`."
+  [platform ns-loc]
   (loop [loc         ns-loc
          found-nodes []]
     (if-let [found-node (z/find-next-depth-first loc (partial after-platform-marker? platform))]
       (recur (z/replace found-node (symbol (str (name platform) "_require"))) (conj found-nodes found-node))
       [found-nodes (z/of-node (z/root loc))])))
 
-(defn- restore-platform-specific-subforms [platform replaced-nodes ns-form]
+(defn- restore-platform-specific-subforms
+  "Inverse of `find-and-replace-platform-specific-subforms`: substitutes each
+  `<platform>_require` placeholder in the rewritten `ns-form` string back with the
+  original `replaced-nodes`."
+  [platform replaced-nodes ns-form]
   (loop [form             ns-form
          [n & rest-nodes] replaced-nodes]
     (if-not n
@@ -534,21 +550,22 @@
             (doall))))))
 
 (defn replace-ns-symbol-in-source-files
-  "Replaces all occurrences of the old name with the new name in
-  all Clojure source files found in dirs."
+  "Replaces all occurrences of `old-sym` with `new-sym` in every Clojure source
+  file under `dirs`. `extension` is the moved namespace's file extension (used to
+  decide which files a rename applies to) and `watermark` the metadata key
+  stamped on the renamed ns. A single-rename convenience wrapper over
+  `replace-ns-symbols-in-source-files`."
   [old-sym new-sym extension dirs watermark]
   (replace-ns-symbols-in-source-files
    [{:old-sym old-sym :new-sym new-sym :extension extension :watermark watermark}]
    dirs))
 
 (defn move-ns
-  "ALPHA: subject to change. Moves the .clj or .cljc source file (found relative
-  to source-path) for the namespace named old-sym to new-sym and
-  replace all occurrences of the old name with the new name in all
-  Clojure source files found in dirs.
-
-  This is partly textual transformation. It works on
-  namespaces require'd or use'd from a prefix list.
+  "ALPHA: subject to change. Moves the source file (of the given `extension`,
+  relative to `source-path`) for namespace `old-sym` to `new-sym`, then replaces
+  all references to the old name with the new name across every Clojure source
+  file under `dirs`. The single-rename combination of `move-ns-files!` and
+  `replace-ns-symbol-in-source-files`.
 
   WARNING: This function modifies and deletes your source files! Make
   sure you have a backup or version control."

--- a/src/mranderson/plugin.clj
+++ b/src/mranderson/plugin.clj
@@ -1,15 +1,28 @@
 (ns mranderson.plugin
+  "Leiningen middleware for MrAnderson. Active only under the
+  `plugin.mranderson/config` profile (see `mranderson.profiles`): drops the
+  source-deps from `:dependencies` and pulls any `:gen-class` namespaces in the
+  inlined sources into `:aot` so they get compiled. Leiningen-only; not used by
+  the `mranderson.core` entry point."
   (:require [mranderson.util :refer [first-src-path clojure-source-files source-dep?]]
             [clojure.tools.namespace.file :refer [read-file-ns-decl]]))
 
-(defn- find-gen-class-ns [found file]
+(defn- find-gen-class-ns
+  "Reducer over source files: conj the namespace symbol of `file` onto `found`
+  when its `ns` form contains a `:gen-class` clause, else return `found`
+  unchanged. Matches the `:gen-class` keyword in the parsed form, not the text,
+  so a docstring or comment that merely mentions it doesn't count."
+  [found file]
   (let [ns-decl (read-file-ns-decl file)]
-    (if (and ns-decl (.contains ^String (apply str ns-decl) ":gen-class"))
+    (if (and ns-decl (some #{:gen-class} (tree-seq coll? seq ns-decl)))
       (conj found (second ns-decl))
       found)))
 
 (defn middleware
-  "Handles :gen-class instances in deps which need AOT"
+  "Leiningen middleware, active only when `:srcdeps-project-hacks` is set (by the
+  `plugin.mranderson/config` profile). Removes the inlined source-deps from
+  `:dependencies` and adds any `:gen-class` namespaces found in the inlined
+  sources to `:aot` so they're compiled. Returns `project` unchanged otherwise."
   [{:keys [source-paths root aot dependencies srcdeps-project-hacks] :as project}]
   (if srcdeps-project-hacks
     (let [src (first-src-path root source-paths)

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -1,4 +1,10 @@
 (ns mranderson.util
+  "Filesystem, class-file and jarjar helpers shared across the pipeline.
+
+  Two concerns live here: locating and normalizing Clojure source dirs and
+  files, and the Java side of inlining - finding bundled `.class` files and
+  relocating their packages via jarjar under a name+version prefix (distinct from
+  the namespace `:project-prefix`)."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [me.raynes.fs :as fs]
@@ -10,6 +16,9 @@
            [org.pantsbuild.jarjar.util StandaloneJarProcessor]))
 
 (defn clojure-source-files-relative
+  "Returns all .clj/.cljc/.cljs files under `dirs` as a vector of File, left
+  as-is (not canonicalized). When `excl-dir` is given, any file under
+  `<dir>/<excl-dir>` for each of `dirs` is excluded."
   ([dirs excl-dir]
      (let [excl-dirs (when excl-dir (map #(str % "/" excl-dir) dirs))]
        (->> dirs
@@ -29,17 +38,24 @@
      (clojure-source-files-relative dirs nil)))
 
 (defn sym->file-name
+  "Converts a namespace symbol to its relative file path (no extension), munging
+  dashes to underscores and dots to the platform file separator."
   [sym]
   (-> (name sym)
       (str/replace "-" "_")
       (str/replace "." File/separator)))
 
-(defn clojure-source-files [dirs]
+(defn clojure-source-files
+  "Like `clojure-source-files-relative`, but returns each file canonicalized."
+  [dirs]
   (->> dirs
        clojure-source-files-relative
        (map #(.getCanonicalFile ^File %))))
 
-(defn class-files [srcdeps]
+(defn class-files
+  "Returns a vector of all `.class` files found under the subdirectories of
+  `srcdeps` (files directly in the root are ignored)."
+  [srcdeps]
   (let [dir (io/file srcdeps)
         subdirs (some-> (.listFiles ^File dir) seq)]
     (->> subdirs
@@ -61,7 +77,10 @@
           path)
         (str/replace #"^[/\\]+" ""))))
 
-(defn class-file->fully-qualified-name [srcdeps file]
+(defn class-file->fully-qualified-name
+  "Returns the fully-qualified (dotted) class name for a `.class` `file`, derived
+  from its path relative to `srcdeps` with the extension dropped."
+  [srcdeps file]
   (->> (-> (srcdeps-relative srcdeps file)
            (str/split #"\.")
            first
@@ -69,7 +88,9 @@
        (str/join ".")))
 
 (defn java-class-dirs
-  "lists subdirs of `srcdeps` which contain .class files"
+  "Returns the set of top-level package roots (the first path segment under
+  `srcdeps`) that contain bundled `.class` files. These are the roots jarjar
+  relocates under the name+version prefix."
   [srcdeps]
   (reduce #(->> (str/split (srcdeps-relative srcdeps %2) #"/")
                 first
@@ -85,20 +106,33 @@
   (str (str/replace pname #"[^a-zA-Z0-9]" "")
        (str/replace pversion #"[^a-zA-Z0-9]" "")))
 
-(defn first-src-path [root source-paths]
+(defn first-src-path
+  "Returns the first of `source-paths` relative to project `root` (the leading
+  `root` prefix and its trailing separator are stripped)."
+  [root source-paths]
   (apply str (drop (inc (count root)) (first source-paths))))
 
-(defn source-dep? [dependency]
+(defn source-dep?
+  "True if `dependency` is marked for inlining, i.e. its metadata carries
+  `:source-dep` or `:inline-dep`."
+  [dependency]
   (let [{:keys [source-dep inline-dep]} (meta dependency)]
     (or source-dep inline-dep)))
 
-(defn- create-rule [name-version java-dir]
+(defn- create-rule
+  "Builds a jarjar `Rule` relocating package `java-dir` (and everything under it)
+  beneath `name-version`."
+  [name-version java-dir]
   (let [rule (Rule.)]
     (. rule setPattern (str java-dir ".**"))
     (. rule setResult (str name-version "." java-dir ".@1"))
     rule))
 
-(defn apply-jarjar! [pname pversion srcdeps jar-file]
+(defn apply-jarjar!
+  "Repackages the bundled Java `.class` files in `jar-file` in place. Relocates
+  every package root found under `srcdeps` (see `java-class-dirs`) beneath the
+  name+version prefix derived from `pname`/`pversion`, via jarjar."
+  [pname pversion srcdeps jar-file]
   (let [java-dirs (java-class-dirs srcdeps)
         name-version (clean-name-version pname pversion)
         rules (map (partial create-rule name-version) java-dirs)
@@ -108,23 +142,34 @@
     (StandaloneJarProcessor/run jar-file jar-file processor)))
 
 (defn file->extension
+  "Returns the Clojure source extension of `file` (\".clj\", \".cljc\" or
+  \".cljs\"), or nil if it has none. Doubles as an is-this-a-source-file?
+  predicate."
   [file]
   (re-find #"\.clj[cs]?$" file))
 
 (defn extension->platform
+  "Returns the platform keyword for a single-platform extension: `:clj` for
+  \".clj\", `:cljs` for \".cljs\". Returns nil for `.cljc` or anything else."
   [extension-of-moved]
   (some->> (#{".cljs" ".clj"} extension-of-moved)
            rest
            (apply str)
            keyword))
 
-(defn platform-comp [platform]
+(defn platform-comp
+  "Returns the complementary platform keyword (`:clj` <-> `:cljs`), or nil when
+  `platform` is nil."
+  [platform]
   (when platform
     (->>  #{platform}
           (s/difference #{:cljs :clj})
           first)))
 
-(defn- cljfile->dir [clj-file]
+(defn- cljfile->dir
+  "Returns the directory portion of slash-separated `clj-file` (its final segment
+  dropped)."
+  [clj-file]
   (->> (str/split clj-file #"/")
        butlast
        (str/join "/")))
@@ -161,14 +206,21 @@
                [])))
 
 (defn clj-files->dirs
+  "Returns the set of distinct directories holding `clj-files`, each prefixed with
+  `prefix` (as `prefix/dir`)."
   [prefix clj-files]
   (->> (map cljfile->dir clj-files)
        (remove str/blank?)
        (map (fn [clj-dir] (str prefix "/" clj-dir)))
        set))
 
-(defn determine-source-dirs [{:keys [source-paths]
-                              {:keys [included-source-paths]} :mranderson}]
+(defn determine-source-dirs
+  "Returns the project source dirs to inline, per the
+  `[:mranderson :included-source-paths]` option: `nil`/`:first` means just the
+  first source path, `:source-paths` means all of them, or an explicit vector of
+  paths is used as-is."
+  [{:keys [source-paths]
+    {:keys [included-source-paths]} :mranderson}]
   (case included-source-paths
     (nil :first) (take 1 source-paths)
     :source-paths source-paths

--- a/test/mranderson/plugin_test.clj
+++ b/test/mranderson/plugin_test.clj
@@ -1,0 +1,24 @@
+(ns mranderson.plugin-test
+  (:require [mranderson.plugin :as sut]
+            [clojure.test :refer [deftest testing is]])
+  (:import java.io.File))
+
+(def ^:private find-gen-class-ns #'sut/find-gen-class-ns)
+
+(defn- ns-file ^File [content]
+  (doto (File/createTempFile "mranderson-plugin" ".clj")
+    (spit content)))
+
+(deftest find-gen-class-ns-test
+  (testing "a namespace with a :gen-class clause is collected for AOT"
+    (let [f (ns-file "(ns real.gc (:gen-class))")]
+      (try (is (= #{'real.gc} (find-gen-class-ns #{} f)))
+           (finally (.delete f)))))
+  (testing "a :gen-class mentioned only in a docstring is ignored (not a real clause)"
+    (let [f (ns-file "(ns doc.gc \"talks about :gen-class in passing\")")]
+      (try (is (= #{} (find-gen-class-ns #{} f)))
+           (finally (.delete f)))))
+  (testing "a namespace without gen-class is left alone"
+    (let [f (ns-file "(ns plain.ns (:require [clojure.string]))")]
+      (try (is (= #{} (find-gen-class-ns #{} f)))
+           (finally (.delete f))))))


### PR DESCRIPTION
A namespace-by-namespace pass over docstrings and comments (audited from four angles), correcting stale ones and backfilling gaps. Eastwood clean, full suite green, self-inline (`make install`) green.

**Stale/wrong, now corrected:**
- `core/prefix-java-imports!` and a sibling comment still described a *per-dependency* Java-import pass that was removed - it's a single global pass now.
- `core/mranderson-resolved-deps!` claimed *reverse* topological order and framed ordering as load-bearing; it's vestigial since the single global rewrite.
- `util/java-class-dirs` was documented as 'subdirs that contain .class files'; it returns the top-level package roots jarjar relocates.
- `resolver/expand-dep-hierarchy` said 'expands the first level' - it's a fully recursive expansion.
- The `lein inline-deps` task docstring (i.e. `lein help inline-deps`) was missing `:overrides`, `:expositions`, and `:watermark`.
- `move/move-ns` carried a tools.namespace-era 'works on a prefix list' clause.

**Backfilled:** namespace docstrings for six namespaces (render on cljdoc), public-API docstrings on the util/tree/resolver helpers and `core/copy-source-files`, and the non-obvious private helpers (`source-replacement`, the cljc platform-masking pair, the import-fragment slicers, the Leiningen option plumbing). Plus typos (`depedency`, `overriden`, `transient` -> `transitive`).

**Bonus fix the audit surfaced:** the Leiningen plugin's gen-class detection matched the *text* `:gen-class` anywhere in a file's ns form, so a docstring that merely mentioned it got the namespace wrongly added to `:aot` (one of my new docstrings tripped exactly this, which the self-inlining integration test caught). It now matches the actual `:gen-class` keyword in the parsed form. New regression test; verified with `make install`.