### PR TITLE
Mark internal namespaces :no-doc for cljdoc [#65]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- [#65](https://github.com/benedekfazekas/mranderson/issues/65) Mark internal namespaces (`mranderson.util`, `mranderson.move`, `mranderson.dependency.*`) `:no-doc` so cljdoc documents only the public API (`mranderson.core`, `mranderson.plugin`, `leiningen.inline-deps`)
+
 ## 0.6.1
 
 ### Bug fixes

--- a/src/mranderson/dependency/resolver.clj
+++ b/src/mranderson/dependency/resolver.clj
@@ -1,4 +1,4 @@
-(ns mranderson.dependency.resolver
+(ns ^:no-doc mranderson.dependency.resolver
   "Dependency resolution via pomegranate/aether.
 
   `resolve-source-deps` produces the resolved tree (Maven conflict resolution has

--- a/src/mranderson/dependency/tree.clj
+++ b/src/mranderson/dependency/tree.clj
@@ -1,4 +1,4 @@
-(ns mranderson.dependency.tree
+(ns ^:no-doc mranderson.dependency.tree
   "Walking and ordering of dependency trees.
 
   A dependency tree here is a nested map of `[name version] -> subtree`. This

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -6,7 +6,8 @@
 ;; agreeing to be bound by the terms of this license. You must not
 ;; remove this notice, or any other, from this software.
 
-(ns ^{:author "Stuart Sierra, Benedek Fazekas"
+(ns ^{:no-doc true
+      :author "Stuart Sierra, Benedek Fazekas"
       :doc    "Refactoring tool to move a Clojure namespace from one name/file to
   another, and update all references to that namespace in your other
   Clojure source files.

--- a/src/mranderson/util.clj
+++ b/src/mranderson/util.clj
@@ -1,4 +1,4 @@
-(ns mranderson.util
+(ns ^:no-doc mranderson.util
   "Filesystem, class-file and jarjar helpers shared across the pipeline.
 
   Two concerns live here: locating and normalizing Clojure source dirs and


### PR DESCRIPTION
cljdoc was listing every namespace, pipeline internals included. This tags the internal namespaces (`mranderson.util`, `mranderson.move`, `mranderson.dependency.resolver`, `mranderson.dependency.tree`) `:no-doc` so the API docs show only the public surface: `mranderson.core`, `mranderson.plugin`, and the `leiningen.inline-deps` task.

The original "API import failed" badge is already resolved for 0.6.1 (it broke because `mranderson.util` used to pull in `leiningen.core`, which isn't on the cljdoc analysis classpath; that reference is long gone). This just cleans up what gets documented.

Fixes #65