### PR TITLE
Skip reader-discard nodes via a zloc wrapper [#82]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- [#82](https://github.com/benedekfazekas/mranderson/issues/82) Leave reader-discarded (`#_`) forms in the `ns` macro untouched during a rename. A symbol buried inside a discarded `:require`/`:import` (e.g. `#_[a.b :as c]`) was previously rewritten, since the guards only skipped the discard node itself, not its contents
+
 ### Changes
 
 - [#65](https://github.com/benedekfazekas/mranderson/issues/65) Mark internal namespaces (`mranderson.util`, `mranderson.move`, `mranderson.dependency.*`) `:no-doc` so cljdoc documents only the public API (`mranderson.core`, `mranderson.plugin`, `leiningen.inline-deps`)
+- [#82](https://github.com/benedekfazekas/mranderson/issues/82) Centralize reader-discard handling in a new internal `mranderson.zloc` namespace that wraps rewrite-clj navigation, instead of scattering `:uneval` checks through `mranderson.move`
 
 ## 0.6.1
 

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -24,6 +24,7 @@
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [mranderson.util :as util]
+            [mranderson.zloc :as zloc]
             [me.raynes.fs :as fs]
             [rewrite-clj.zip :as z]
             [rewrite-clj.node :as n]
@@ -72,9 +73,8 @@
 
 (defn- java-style-prefix?
   [old-sym node]
-  (when-not (#{:uneval} (z/tag node))
-    (when-let [node-sexpr (z/sexpr node)]
-      (str/starts-with? node-sexpr (java-package old-sym)))))
+  (when-let [node-sexpr (z/sexpr node)]
+    (str/starts-with? node-sexpr (java-package old-sym))))
 
 (defn- libspec-prefix?
   [node node-sexpr old-sym]
@@ -82,20 +82,17 @@
         first-node?            (z/leftmost? node)
         parent-leftmost-node   (z/leftmost (z/up node))
         parent-leftmost-sexpr  (and parent-leftmost-node
-                                    (not
-                                     (#{:uneval}
-                                      (z/tag parent-leftmost-node)))
+                                    (not (zloc/uneval? parent-leftmost-node))
                                     (z/sexpr parent-leftmost-node))]
     (and first-node?
          (= :require parent-leftmost-sexpr)
          (= node-sexpr old-sym-prefix-libspec))))
 
 (defn- contains-sym? [old-sym node]
-  (when-not (#{:uneval} (z/tag node))
-    (when-let [node-sexpr (z/sexpr node)]
-      (or
-       (= node-sexpr old-sym)
-       (libspec-prefix? node node-sexpr old-sym)))))
+  (when-let [node-sexpr (z/sexpr node)]
+    (or
+     (= node-sexpr old-sym)
+     (libspec-prefix? node node-sexpr old-sym))))
 
 (defn- ->new-node [old-node old-sym new-sym]
   (let [old-prefix (prefix-libspec old-sym)]
@@ -119,7 +116,7 @@
       :else new-node)))
 
 (defn- ns-decl? [node]
-  (when-not (#{:uneval} (z/tag node))
+  (when-not (zloc/uneval? node)
     (= 'ns (z/sexpr (z/down node)))))
 
 (def ^:const ns-form-placeholder (str "ns_" "form_" "placeholder"))
@@ -138,9 +135,8 @@
           [nil content])))))
 
 (defn- import? [node]
-  (when-not (#{:uneval} (z/tag node))
-    (when-let [node-sexpr (z/sexpr node)]
-      (= :import node-sexpr))))
+  (when-let [node-sexpr (z/sexpr node)]
+    (= :import node-sexpr)))
 
 (defn- ->new-import-node [old-sym new-sym old-node]
   (let [new-node (str/replace old-node (java-package old-sym) (java-package new-sym))]
@@ -152,33 +148,18 @@
 (defn- replace-in-import* [import-loc old-sym new-sym]
   (loop [loc import-loc]
     (if-let [found-node (some-> loc
-                                (z/find-next-depth-first (partial java-style-prefix? old-sym))
+                                (zloc/find-next-depth-first (partial java-style-prefix? old-sym))
                                 (z/edit (partial ->new-import-node old-sym new-sym)))]
       (recur found-node)
       (z/root loc))))
 
 (defn- replace-in-import [ns-loc old-sym new-sym]
-  (if-let [import-loc (some-> (z/find-next-depth-first ns-loc import?)
+  (if-let [import-loc (some-> (zloc/find-next-depth-first ns-loc import?)
                               (z/up))]
     (-> (z/replace import-loc (replace-in-import* (z/of-node (z/node import-loc)) old-sym new-sym))
         z/root
         z/of-node)
     ns-loc))
-
-(defn- zskip-unintresting
-  ;; TODO: move to a zloc ns and expand to handle all zip operations
-  "Rewrite-clj only skips whitespace and comments.
-  We'd also like to skip reader discard #_ nodes (aka uneval nodes in rewrite-clj)."
-  [zloc]
-  (z/skip z/right* #(or (z/whitespace-or-comment? %)
-                        (= :uneval (z/tag %)))
-          zloc))
-
-(defn- zdown [zloc]
-  (some-> zloc z/down* zskip-unintresting))
-
-(defn- zright [zloc]
-  (some-> zloc z/right* zskip-unintresting))
 
 (defn ^:no-doc rename-ns
   ;; exposed only for unit testing, could move to impl ns
@@ -192,7 +173,7 @@
   We make an effort to preserve existing ordering and syntax of metadata."
   [ns-loc old-ns-name new-ns-name add-meta-kw]
   (when ns-loc
-    (let [ns-name-loc (some-> ns-loc zdown zright)
+    (let [ns-name-loc (some-> ns-loc zloc/down zloc/right)
           cur-has-meta? (= :meta (z/tag ns-name-loc))
           ns-loc (cond
                    (not= (z/sexpr ns-name-loc) old-ns-name)
@@ -200,15 +181,15 @@
 
                    add-meta-kw
                    (if cur-has-meta?
-                     (cond-> (zdown ns-name-loc)
+                     (cond-> (zloc/down ns-name-loc)
                        ;; convert existing ^:some-meta to ^{:some-meta true ...}
-                       (-> ns-name-loc zdown z/node n/keyword-node?)
+                       (-> ns-name-loc zloc/down z/node n/keyword-node?)
                        (z/edit (fn [kw] (n/map-node [kw (n/spaces 1) true])))
 
                        ;; append our new meta to existing ^{:some-meta true ...}
                        :always
                        (-> (z/assoc add-meta-kw true)
-                           zright
+                           zloc/right
                            (z/replace new-ns-name)))
                      ;; no existing meta, add it in
                      (-> ns-name-loc
@@ -218,8 +199,8 @@
 
                    cur-has-meta?
                    (-> ns-name-loc
-                       zdown ;; to current meta
-                       zright ;; to namespace name
+                       zloc/down ;; to current meta
+                       zloc/right ;; to namespace name
                        (z/replace new-ns-name))
 
                    :else
@@ -232,7 +213,7 @@
 (defn- replace-in-ns-form [ns-loc old-sym new-sym watermark]
   (loop [loc (-> (rename-ns ns-loc old-sym new-sym watermark)
                  (replace-in-import old-sym new-sym))]
-    (if-let [found-node (some-> (z/find-next-depth-first loc (partial contains-sym? old-sym))
+    (if-let [found-node (some-> (zloc/find-next-depth-first loc (partial contains-sym? old-sym))
                                 (z/edit (partial replace-in-node old-sym new-sym)))]
       (recur found-node)
       (z/root-string loc))))
@@ -312,8 +293,7 @@
     (str/replace source-sans-ns regex (partial source-replacement old-sym new-sym))))
 
 (defn- after-platform-marker? [platform node]
-  (when-not (#{:uneval} (z/tag node))
-    (= platform (z/sexpr (z/left node)))))
+  (= platform (z/sexpr (z/left node))))
 
 (defn- find-and-replace-platform-specific-subforms
   "In a `.cljc` ns form, masks the subforms belonging to `platform` (the opposite
@@ -323,7 +303,7 @@
   [platform ns-loc]
   (loop [loc         ns-loc
          found-nodes []]
-    (if-let [found-node (z/find-next-depth-first loc (partial after-platform-marker? platform))]
+    (if-let [found-node (zloc/find-next-depth-first loc (partial after-platform-marker? platform))]
       (recur (z/replace found-node (symbol (str (name platform) "_require"))) (conj found-nodes found-node))
       [found-nodes (z/of-node (z/root loc))])))
 

--- a/src/mranderson/zloc.clj
+++ b/src/mranderson/zloc.clj
@@ -1,0 +1,52 @@
+(ns ^:no-doc mranderson.zloc
+  "Thin wrappers over rewrite-clj navigation that also skip reader-discard
+  (`#_`, aka uneval) nodes. Rewrite-clj skips whitespace and comments on its
+  own, but not discarded forms, so without these wrappers `mranderson.move`
+  would have to guard against `:uneval` nodes at every step (and could still
+  rewrite symbols buried inside a discarded form). Centralizing it here keeps
+  that concern in one place."
+  (:require [rewrite-clj.zip :as z]))
+
+(defn uneval?
+  "True if `zloc` is positioned on a reader-discard (`#_`) node."
+  [zloc]
+  (= :uneval (z/tag zloc)))
+
+(defn- uninteresting?
+  "Whitespace, comment or reader-discard - nodes navigation should step over."
+  [zloc]
+  (or (z/whitespace-or-comment? zloc)
+      (uneval? zloc)))
+
+(defn skip-uninteresting
+  "Skip rightward over whitespace, comments and reader-discard nodes, starting
+  from `zloc`."
+  [zloc]
+  (z/skip z/right* uninteresting? zloc))
+
+(defn down
+  "Like `z/down`, but also steps over reader-discard nodes."
+  [zloc]
+  (some-> zloc z/down* skip-uninteresting))
+
+(defn right
+  "Like `z/right`, but also steps over reader-discard nodes."
+  [zloc]
+  (some-> zloc z/right* skip-uninteresting))
+
+(defn in-uneval?
+  "True if `zloc` is a reader-discard node or sits anywhere inside one. Unlike a
+  bare `uneval?` tag check, this also catches nodes nested within a discarded
+  form."
+  [zloc]
+  (loop [loc zloc]
+    (cond
+      (nil? loc)   false
+      (uneval? loc) true
+      :else        (recur (z/up* loc)))))
+
+(defn find-next-depth-first
+  "Like `z/find-next-depth-first`, but never matches a node that lies inside a
+  reader-discard (`#_`) form, so discarded code is left untouched."
+  [zloc pred]
+  (z/find-next-depth-first zloc #(and (not (in-uneval? %)) (pred %))))

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -421,3 +421,17 @@
       (t/is (str/includes?
              (sut/replace-ns-symbols body renames ".clj")
              "pre.com.acme.impl.Widget.")))))
+
+(t/deftest replace-ns-symbols-skips-reader-discards
+  ;; #82: a reader-discarded (#_) form in the ns macro must be left untouched,
+  ;; even when it holds a symbol matching a rename. Only the live occurrence is
+  ;; rewritten.
+  (let [renames [{:old-sym 'a.b :new-sym 'x.y :extension ".clj" :watermark nil}]]
+    (t/testing "discarded :require libspec survives, live one is renamed"
+      (let [out (sut/replace-ns-symbols "(ns foo (:require #_[a.b :as old] [a.b :as live]))" renames ".clj")]
+        (t/is (str/includes? out "#_[a.b :as old]"))
+        (t/is (str/includes? out "[x.y :as live]"))))
+    (t/testing "discarded :import survives, live one is renamed"
+      (let [out (sut/replace-ns-symbols "(ns foo (:import #_[a.b Thing] [a.b Live]))" renames ".clj")]
+        (t/is (str/includes? out "#_[a.b Thing]"))
+        (t/is (str/includes? out "[x.y Live]"))))))

--- a/test/mranderson/zloc_test.clj
+++ b/test/mranderson/zloc_test.clj
@@ -1,0 +1,25 @@
+(ns mranderson.zloc-test
+  (:require [mranderson.zloc :as sut]
+            [rewrite-clj.zip :as z]
+            [clojure.test :as t]))
+
+(t/deftest down-and-right-skip-discards
+  (t/testing "down skips a leading reader-discard"
+    (t/is (= 'a (-> "(#_skip a b)" z/of-string sut/down z/sexpr))))
+  (t/testing "right skips a reader-discard between siblings"
+    (t/is (= 'b (-> "(a #_skip b)" z/of-string sut/down sut/right z/sexpr))))
+  (t/testing "down/right skip a double discard (#_#_)"
+    (t/is (= 'c (-> "(#_#_a b c)" z/of-string sut/down z/sexpr)))))
+
+(t/deftest in-uneval?-detects-nesting
+  (let [loc (z/of-string "(:require #_[a.b :as c] [a.b :as r])")
+        discarded (z/find-next-depth-first loc #(= 'c (try (z/sexpr %) (catch Exception _ nil))))
+        live      (z/find-next-depth-first loc #(= 'r (try (z/sexpr %) (catch Exception _ nil))))]
+    (t/is (true? (sut/in-uneval? discarded)) "a node inside #_ is flagged")
+    (t/is (false? (sut/in-uneval? live)) "a live node is not flagged")))
+
+(t/deftest find-next-depth-first-skips-discarded
+  (let [loc (z/of-string "(:require #_[a.b :as c] [a.b :as r])")
+        hit (sut/find-next-depth-first loc #(= 'a.b (try (z/sexpr %) (catch Exception _ nil))))]
+    (t/is (some? hit) "the live a.b is found")
+    (t/is (false? (sut/in-uneval? hit)) "and it is the live one, not the discarded one")))


### PR DESCRIPTION
rewrite-clj skips whitespace and comments during navigation, but not reader-discard (`#_`) forms, so `mranderson.move` was sprinkled with `:uneval` guards. Those guards only rejected the discard node itself, not symbols nested inside it, so a rename could rewrite a symbol in a discarded `:require`/`:import` (e.g. `#_[a.b :as c]` became `#_[x.y :as c]`). Harmless at runtime since the form is discarded, but it shouldn't happen.

This adds an internal `mranderson.zloc` namespace that wraps rewrite-clj navigation (`down`/`right` and a depth-first `find`) so discarded forms are skipped universally, and drops the scattered `:uneval` checks. The maintainer who filed the issue suggested exactly this; I went with `mranderson.zloc` (flat, like the other namespaces) since there's no `impl`/`internal` namespace convention in the tree.

Tests: a unit suite for the wrapper plus a regression proving discarded `:require`/`:import` forms in the `ns` macro survive a rename while live ones are renamed.

Fixes #82