### PR TITLE
Document recursive re-inlining with a regression test [#39]

### DIFF
--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -435,3 +435,30 @@
       (let [out (sut/replace-ns-symbols "(ns foo (:import #_[a.b Thing] [a.b Live]))" renames ".clj")]
         (t/is (str/includes? out "#_[a.b Thing]"))
         (t/is (str/includes? out "[x.y Live]"))))))
+
+(t/deftest replace-ns-symbols-handles-already-inlined-sources
+  ;; #39: MrAnderson can inline a library that was itself built by inlining its
+  ;; deps (so it ships watermarked, already-prefixed namespaces). The watermark
+  ;; is write-only - nothing reads it back - so such namespaces are simply
+  ;; re-prefixed, nesting one inline inside the other. This locks in that the
+  ;; rewrite layer handles that cleanly.
+  (let [;; a namespace as it ships inside an already-inlined library `libl`
+        source  (str "(ns ^{:mranderson/inlined true} libl.inlined-deps.dep.core\n"
+                     "  (:require [libl.inlined-deps.dep.util :as u]))\n"
+                     "(defn go [] (u/help libl.inlined-deps.dep.util.Widget))")
+        renames [{:old-sym 'libl.inlined-deps.dep.core
+                  :new-sym 'proj.inlined-deps.libl.inlined-deps.dep.core
+                  :extension ".clj" :watermark :mranderson/inlined}
+                 {:old-sym 'libl.inlined-deps.dep.util
+                  :new-sym 'proj.inlined-deps.libl.inlined-deps.dep.util
+                  :extension ".clj" :watermark :mranderson/inlined}]
+        out     (sut/replace-ns-symbols source renames ".clj")]
+    (t/testing "the already-inlined ns name gets the new nested prefix"
+      (t/is (str/includes? out "proj.inlined-deps.libl.inlined-deps.dep.core")))
+    (t/testing "the existing watermark is preserved, not duplicated"
+      (t/is (str/includes? out "^{:mranderson/inlined true}"))
+      (t/is (= 1 (count (re-seq #":mranderson/inlined" out)))))
+    (t/testing "an internal require is repointed to the nested prefix"
+      (t/is (str/includes? out "[proj.inlined-deps.libl.inlined-deps.dep.util :as u]")))
+    (t/testing "a fully-qualified class reference is nested and Java-munged"
+      (t/is (str/includes? out "proj.inlined_deps.libl.inlined_deps.dep.util.Widget")))))


### PR DESCRIPTION
#39 asks what happens when MrAnderson inlines a library that was itself built with MrAnderson (so it ships watermarked, already-inlined namespaces).

The short answer: it just works at the rewrite layer. The `:mranderson/inlined` watermark is write-only - nothing ever reads it back - so an already-inlined namespace is treated like any other and simply re-prefixed, nesting one inline within the other (`proj.inlined-deps.libl.inlined-deps.dep.core`). This adds a regression test pinning that down: the nested prefix is applied, the existing watermark is preserved (not duplicated), internal requires are repointed, and fully-qualified class references are Java-munged.

Scope note: this covers the namespace rewriting, which is the part with the interesting edge cases. The jarjar `.class` relocation is generic package relocation and would nest the same way. An opt-in 'skip already-inlined' mode (which the issue floats) is a separate feature with a real design call, so I left it out.

Refs #39