### PR TITLE
Add :print-deps-tree option to print the tree and exit [#24]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#82](https://github.com/benedekfazekas/mranderson/issues/82): Leave reader-discarded (`#_`) forms in the `ns` macro untouched during a rename. A symbol buried inside a discarded `:require`/`:import` (e.g. `#_[a.b :as c]`) was previously rewritten, since the guards only skipped the discard node itself, not its contents
 
+### New features
+
+- [#24](https://github.com/benedekfazekas/mranderson/issues/24): Add a `:print-deps-tree` option (and `mranderson.core/print-deps-tree`) that prints the dependency tree inlining would process and exits without inlining: `lein inline-deps :print-deps-tree true`
+
 ### Changes
 
 - [#65](https://github.com/benedekfazekas/mranderson/issues/65): Mark internal namespaces (`mranderson.util`, `mranderson.move`, `mranderson.dependency.*`) `:no-doc` so cljdoc documents only the public API (`mranderson.core`, `mranderson.plugin`, `leiningen.inline-deps`)

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ below; see its docstring for the authoritative list.
 | overrides                | empty list                     |  Defines dependency overrides in **unresolved tree** mode | `:mranderson {:overrides {[mvxcvi/puget fipp] [fipp "0.6.15"]}}` |
 | expositions              | empty list                     |  Makes transitive dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
 | included-source-paths    | nil                            |  (Leiningen task only.) Determines which of the provided `:source-paths` (not `:test-paths`!) will be inlined. If `nil` or `:first`, the first source path (typically `"src"`) will be the only one to be processed. If set to `:source-paths`, all `:source-paths` will be processed. If set to a vector, that vector will be interpreted as the list of source dirs to be processed, as-is, ignoring the project's `:source-paths` value. |
+| print-deps-tree          | false                          |  Print the dependency tree that would be inlined (the resolved tree, or the unresolved one in **unresolved tree** mode) and exit without inlining anything. | `lein inline-deps :print-deps-tree true` |
 
 ## Prerequisites
 

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -69,7 +69,8 @@
      :unresolved-tree             (lookup-opt :unresolved-tree cli-opts mranderson)
      :overrides                   (lookup-opt :overrides cli-opts mranderson)
      :expositions                 (lookup-opt :expositions cli-opts mranderson)
-     :watermark                   (lookup-opt :watermark cli-opts mranderson :mranderson/inlined)}))
+     :watermark                   (lookup-opt :watermark cli-opts mranderson :mranderson/inlined)
+     :print-deps-tree             (lookup-opt :print-deps-tree cli-opts mranderson)}))
 
 (defn- initial-paths [target-path pprefix]
   {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
@@ -90,10 +91,13 @@
   :unresolved-tree          boolean   Enforces unresolved tree mode
   :overrides                map       Dependency overrides, unresolved-tree mode only
   :expositions              list      Transitive deps exposed to the project's own sources, unresolved-tree mode only
-  :watermark                keyword   Metadata key added to inlined namespaces (default: :mranderson/inlined; nil to disable)"
+  :watermark                keyword   Metadata key added to inlined namespaces (default: :mranderson/inlined; nil to disable)
+  :print-deps-tree          boolean   Print the dependency tree that would be inlined, then exit without inlining"
   [{:keys [repositories dependencies target-path] :as project} & args]
-  (warn-on-aot project)
-  (c/copy-source-files (u/determine-source-dirs project) target-path)
-  (let [{:keys [pprefix] :as ctx} (lein-project->ctx project args)
-        paths                     (initial-paths target-path pprefix)]
-    (c/mranderson repositories dependencies ctx paths)))
+  (let [{:keys [pprefix print-deps-tree] :as ctx} (lein-project->ctx project args)]
+    (if print-deps-tree
+      (c/print-deps-tree repositories dependencies ctx)
+      (do
+        (warn-on-aot project)
+        (c/copy-source-files (u/determine-source-dirs project) target-path)
+        (c/mranderson repositories dependencies ctx (initial-paths target-path pprefix))))))

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -525,6 +525,32 @@
   [dependencies]
   (mapv #(vary-meta % assoc :inline-dep true) dependencies))
 
+(defn- deps-tree-lines
+  "Renders a dependency `tree` (a nested `[name version] -> subtree` map) to a
+  vector of strings, one coordinate per line, indented two spaces per level."
+  [tree]
+  (let [lines (volatile! [])]
+    (t/walk-deps tree (fn [dep level]
+                        (vswap! lines conj (str (apply str (repeat (* 2 level) \space))
+                                                (pr-str dep)))))
+    @lines))
+
+(defn print-deps-tree
+  "Resolves the inlinable entries of `dependencies` against `repositories` and
+  prints the dependency tree that inlining would process, then returns nil
+  without inlining anything. Prints the resolved tree, or the unresolved (deeply
+  nested) tree when `:unresolved-tree` is set in `opts` (honoring `:overrides`),
+  to match what the corresponding mode would actually walk. Backs the
+  `:print-deps-tree` option."
+  [repositories dependencies {:keys [unresolved-tree overrides]}]
+  (let [source-deps   (filter u/source-dep? dependencies)
+        resolved-tree (dr/resolve-source-deps repositories source-deps)
+        tree          (if unresolved-tree
+                        (dr/expand-dep-hierarchy repositories resolved-tree (or overrides {}))
+                        resolved-tree)]
+    (doseq [line (deps-tree-lines tree)]
+      (log/info line))))
+
 (defn inline-deps
   "Inline and shadow `:dependencies` so they cannot interfere with the
   dependencies of downstream consumers.
@@ -575,8 +601,11 @@
                        unresolved-tree mode.
   - `:watermark`       meta key marking inlined namespaces. Defaults to
                        `:mranderson/inlined`.
+  - `:print-deps-tree` when true, print the dependency tree that would be inlined
+                       and return without inlining anything. Defaults to `false`.
 
-  Returns the resolved project prefix (handy when it was generated)."
+  Returns the resolved project prefix (handy when it was generated), or nil for a
+  `:print-deps-tree` run."
   [{:keys [dependencies source-paths project-prefix target-path repositories
            pname pversion skip-repackage-java-classes prefix-exclusions
            unresolved-tree overrides expositions watermark]
@@ -586,31 +615,35 @@
            pversion                    "0.0.0"
            skip-repackage-java-classes false
            unresolved-tree             false
-           watermark                   :mranderson/inlined}}]
+           watermark                   :mranderson/inlined}
+    :as   opts}]
   (assert (seq dependencies) ":dependencies must be a non-empty collection")
-  (assert (seq source-paths) ":source-paths must be a non-empty collection")
-  (let [target-path (str target-path)
-        pprefix     (or (some-> project-prefix name) (default-project-prefix))]
-    ;; The project's own sources have to live next to the inlined deps so that
-    ;; their references can be rewritten too.
-    (copy-source-files source-paths target-path)
-    (let [srcdeps             (str target-path "/srcdeps")
-          ;; At this point srcdeps only holds the copied project sources; the
-          ;; prefix dir for the deps does not exist yet.
-          project-source-dirs (filter fs/directory? (or (.listFiles (io/file srcdeps)) []))
-          ctx                 {:pname                       pname
-                               :pversion                    (str pversion)
-                               :pprefix                     pprefix
-                               :skip-repackage-java-classes skip-repackage-java-classes
-                               :srcdeps                     srcdeps
-                               :prefix-exclusions           prefix-exclusions
-                               :project-source-dirs         project-source-dirs
-                               :unresolved-tree             unresolved-tree
-                               :overrides                   overrides
-                               :expositions                 expositions
-                               :watermark                   watermark}
-          paths               {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
-                               :parent-clj-dirs []
-                               :branch          []}]
-      (mranderson repositories (mark-inline dependencies) ctx paths)
-      pprefix)))
+  (if (:print-deps-tree opts)
+    (print-deps-tree repositories (mark-inline dependencies) opts)
+    (do
+      (assert (seq source-paths) ":source-paths must be a non-empty collection")
+      (let [target-path (str target-path)
+            pprefix     (or (some-> project-prefix name) (default-project-prefix))]
+        ;; The project's own sources have to live next to the inlined deps so that
+        ;; their references can be rewritten too.
+        (copy-source-files source-paths target-path)
+        (let [srcdeps             (str target-path "/srcdeps")
+              ;; At this point srcdeps only holds the copied project sources; the
+              ;; prefix dir for the deps does not exist yet.
+              project-source-dirs (filter fs/directory? (or (.listFiles (io/file srcdeps)) []))
+              ctx                 {:pname                       pname
+                                   :pversion                    (str pversion)
+                                   :pprefix                     pprefix
+                                   :skip-repackage-java-classes skip-repackage-java-classes
+                                   :srcdeps                     srcdeps
+                                   :prefix-exclusions           prefix-exclusions
+                                   :project-source-dirs         project-source-dirs
+                                   :unresolved-tree             unresolved-tree
+                                   :overrides                   overrides
+                                   :expositions                 expositions
+                                   :watermark                   watermark}
+              paths               {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
+                                   :parent-clj-dirs []
+                                   :branch          []}]
+          (mranderson repositories (mark-inline dependencies) ctx paths)
+          pprefix)))))

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -1,5 +1,6 @@
 (ns mranderson.core-test
   (:require [mranderson.core :as sut]
+            [mranderson.dependency.resolver]
             [mranderson.test :refer [with-mranderson]]
             [mranderson.util :as util]
             [clojure.java.io :as io]
@@ -451,3 +452,43 @@
         (is (not (string/includes?
                   content
                   (str prefix ".claypoole.v1v1v4.com.climate.claypoole.impl PriorityThreadpoolImpl"))))))))
+
+;; ## #24 - print the dependency tree and exit
+
+(def ^:private deps-tree-lines #'sut/deps-tree-lines)
+
+(deftest t-deps-tree-lines
+  (testing "renders a nested dep tree, two spaces of indent per level"
+    (let [tree (array-map
+                ['a "1"] (array-map ['b "2"] nil
+                                    ['c "3"] (array-map ['d "4"] nil))
+                ['e "5"] nil)]
+      (is (= ["[a \"1\"]"
+              "  [b \"2\"]"
+              "  [c \"3\"]"
+              "    [d \"4\"]"
+              "[e \"5\"]"]
+             (deps-tree-lines tree))))))
+
+(deftest t-print-deps-tree
+  (testing "prints the resolved tree and inlines nothing"
+    (let [resolved (array-map ['org.clojure/tools.namespace "1.4.4"]
+                              (array-map ['org.clojure/java.classpath "1.0.0"] nil))]
+      (with-redefs [mranderson.dependency.resolver/resolve-source-deps
+                    (fn [_repos _deps] resolved)]
+        (let [out (with-out-str
+                    (sut/print-deps-tree []
+                                         '[^:inline-dep [org.clojure/tools.namespace "1.4.4"]]
+                                         {}))]
+          (is (string/includes? out "[org.clojure/tools.namespace \"1.4.4\"]"))
+          (is (string/includes? out "  [org.clojure/java.classpath \"1.0.0\"]"))))))
+  (testing "prints the unresolved tree when unresolved-tree mode is on"
+    (let [resolved   (array-map ['top "1"] nil)
+          unresolved (array-map ['top "1"] (array-map ['nested "2"] nil))]
+      (with-redefs [mranderson.dependency.resolver/resolve-source-deps
+                    (fn [_repos _deps] resolved)
+                    mranderson.dependency.resolver/expand-dep-hierarchy
+                    (fn [_repos _tree _overrides] unresolved)]
+        (let [out (with-out-str
+                    (sut/print-deps-tree [] '[^:inline-dep [top "1"]] {:unresolved-tree true}))]
+          (is (string/includes? out "  [nested \"2\"]")))))))


### PR DESCRIPTION
Closes #24. Adds a `:print-deps-tree` option that resolves the dependencies and prints the tree inlining would walk, then exits without inlining anything.

```
$ lein inline-deps :print-deps-tree true
[org.clojure/data.xml "0.2.0-alpha6"]
  [org.clojure/clojure "1.7.0"]
  [org.clojure/data.codec "0.1.0"]
```

It prints the resolved tree, or the unresolved (deeply nested) tree when in unresolved-tree mode, to match what that mode would actually process. Wired into both the `lein inline-deps` task and `mranderson.core/inline-deps` (the tools.deps entry), and exposed as a public `mranderson.core/print-deps-tree`. The print path returns before copying sources or touching `srcdeps`, so it has no side effects beyond resolution.

Tests cover the pure tree rendering and the resolved/unresolved selection (resolver stubbed to stay offline); also smoke-tested end to end against a real dependency.

Fixes #24