### PR TITLE
Add :report option for a per-file run report [#43]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New features
 
 - [#24](https://github.com/benedekfazekas/mranderson/issues/24): Add a `:print-deps-tree` option (and `mranderson.core/print-deps-tree`) that prints the dependency tree inlining would process and exits without inlining: `lein inline-deps :print-deps-tree true`
+- [#43](https://github.com/benedekfazekas/mranderson/issues/43): Add a `:report` option that, after inlining, prints a per-file summary of which namespaces' references were rewritten in each file and how many: `lein inline-deps :report true` (resolved-tree mode only)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ below; see its docstring for the authoritative list.
 | expositions              | empty list                     |  Makes transitive dependencies available in the project's source files in **unresolved tree** mode | `:mranderson {:expositions [[mvxcvi/puget fipp]]}` |
 | included-source-paths    | nil                            |  (Leiningen task only.) Determines which of the provided `:source-paths` (not `:test-paths`!) will be inlined. If `nil` or `:first`, the first source path (typically `"src"`) will be the only one to be processed. If set to `:source-paths`, all `:source-paths` will be processed. If set to a vector, that vector will be interpreted as the list of source dirs to be processed, as-is, ignoring the project's `:source-paths` value. |
 | print-deps-tree          | false                          |  Print the dependency tree that would be inlined (the resolved tree, or the unresolved one in **unresolved tree** mode) and exit without inlining anything. | `lein inline-deps :print-deps-tree true` |
+| report                   | false                          |  After inlining, print a per-file report of which namespaces' references were rewritten in each file, with reference counts. **Resolved tree** mode only. | `lein inline-deps :report true` |
 
 ## Prerequisites
 

--- a/src/leiningen/inline_deps.clj
+++ b/src/leiningen/inline_deps.clj
@@ -70,7 +70,8 @@
      :overrides                   (lookup-opt :overrides cli-opts mranderson)
      :expositions                 (lookup-opt :expositions cli-opts mranderson)
      :watermark                   (lookup-opt :watermark cli-opts mranderson :mranderson/inlined)
-     :print-deps-tree             (lookup-opt :print-deps-tree cli-opts mranderson)}))
+     :print-deps-tree             (lookup-opt :print-deps-tree cli-opts mranderson)
+     :report                      (lookup-opt :report cli-opts mranderson)}))
 
 (defn- initial-paths [target-path pprefix]
   {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
@@ -92,7 +93,8 @@
   :overrides                map       Dependency overrides, unresolved-tree mode only
   :expositions              list      Transitive deps exposed to the project's own sources, unresolved-tree mode only
   :watermark                keyword   Metadata key added to inlined namespaces (default: :mranderson/inlined; nil to disable)
-  :print-deps-tree          boolean   Print the dependency tree that would be inlined, then exit without inlining"
+  :print-deps-tree          boolean   Print the dependency tree that would be inlined, then exit without inlining
+  :report                   boolean   After inlining, print a per-file report of which namespaces' references were rewritten (resolved-tree mode only)"
   [{:keys [repositories dependencies target-path] :as project} & args]
   (let [{:keys [pprefix print-deps-tree] :as ctx} (lein-project->ctx project args)]
     (if print-deps-tree

--- a/src/mranderson/core.clj
+++ b/src/mranderson/core.clj
@@ -474,6 +474,22 @@
                        (apply concat))]
       (move/replace-ns-symbols-in-source-files renames [(:srcdeps ctx)] (java-class-fqns (:srcdeps ctx))))))
 
+(defn- print-run-report
+  "Prints a human-readable summary of the run: each changed file and the
+  namespaces whose references were rewritten in it, with reference counts.
+  Resolved-tree mode only - unresolved-tree mode rewrites per subtree and does
+  not collect a report."
+  [reports {:keys [srcdeps pprefix unresolved-tree]}]
+  (if unresolved-tree
+    (log/info "run report is only available in resolved-tree mode")
+    (let [reports (sort-by #(str (:file %)) reports)]
+      (log/info (format "Inlined %d file(s) under %s:" (count reports) pprefix))
+      (doseq [{:keys [file renames]}        reports
+              {:keys [old-sym new-sym refs]} renames]
+        (log/info (format "  %s: %s -> %s (%d ref%s)"
+                          (u/srcdeps-relative srcdeps file)
+                          old-sym new-sym refs (if (= 1 refs) "" "s")))))))
+
 (defn mranderson
   "Inline and shadow dependencies so they can not interfere with other libraries' dependencies.
 
@@ -488,26 +504,29 @@
   - unresolved-tree: switch to unresolved tree mode if true
   - overrides: overrides in the unresolved tree in unresolved tree mode
   - expositions: transitive dependencies made available for the project source files in unresolved tree mode
-  - watermark: meta flag to mark inlined dependencies"
+  - watermark: meta flag to mark inlined dependencies
+  - report: print a per-file run report when true (resolved-tree mode only)"
 
-  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps prefix-exclusions] :as ctx} paths]
+  [repositories dependencies {:keys [skip-repackage-java-classes unresolved-tree pname pversion overrides srcdeps prefix-exclusions report] :as ctx} paths]
   (let [source-dependencies         (filter u/source-dep? dependencies)
         resolved-deps-tree          (dr/resolve-source-deps repositories source-dependencies)
         overrides                   (or (and unresolved-tree overrides) {})
         unresolved-deps-tree        (dr/expand-dep-hierarchy repositories resolved-deps-tree overrides)]
     (log/info "retrieve dependencies and munge clojure source files")
-    (if unresolved-tree
-      (mranderson-unresolved-deps! unresolved-deps-tree paths ctx)
-      (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))
-    (when-not (or skip-repackage-java-classes (empty? (u/class-files srcdeps)))
-      (let [jar-file (fs/file (fs/parent srcdeps) "class-deps.jar")]
-        ;; rewrite java imports across all inlined sources (deps + the project's
-        ;; own files) while the class files are still in their original
-        ;; (unprefixed) locations, so their names are known
-        (prefix-java-imports! pname pversion srcdeps prefix-exclusions)
-        (class-deps-jar! srcdeps jar-file)
-        (u/apply-jarjar! pname pversion srcdeps jar-file)
-        (replace-class-deps! srcdeps jar-file)))))
+    (let [reports (if unresolved-tree
+                    (mranderson-unresolved-deps! unresolved-deps-tree paths ctx)
+                    (mranderson-resolved-deps! resolved-deps-tree unresolved-deps-tree paths ctx))]
+      (when-not (or skip-repackage-java-classes (empty? (u/class-files srcdeps)))
+        (let [jar-file (fs/file (fs/parent srcdeps) "class-deps.jar")]
+          ;; rewrite java imports across all inlined sources (deps + the project's
+          ;; own files) while the class files are still in their original
+          ;; (unprefixed) locations, so their names are known
+          (prefix-java-imports! pname pversion srcdeps prefix-exclusions)
+          (class-deps-jar! srcdeps jar-file)
+          (u/apply-jarjar! pname pversion srcdeps jar-file)
+          (replace-class-deps! srcdeps jar-file)))
+      (when report
+        (print-run-report reports ctx)))))
 
 (def default-repositories
   "Maven repositories used to resolve dependencies when none are supplied."
@@ -603,12 +622,15 @@
                        `:mranderson/inlined`.
   - `:print-deps-tree` when true, print the dependency tree that would be inlined
                        and return without inlining anything. Defaults to `false`.
+  - `:report`          when true, print a per-file run report (which namespaces'
+                       references were rewritten in each file) after inlining.
+                       Resolved-tree mode only. Defaults to `false`.
 
   Returns the resolved project prefix (handy when it was generated), or nil for a
   `:print-deps-tree` run."
   [{:keys [dependencies source-paths project-prefix target-path repositories
            pname pversion skip-repackage-java-classes prefix-exclusions
-           unresolved-tree overrides expositions watermark]
+           unresolved-tree overrides expositions watermark report]
     :or   {target-path                 "target"
            repositories                default-repositories
            pname                       "mranderson"
@@ -641,7 +663,8 @@
                                    :unresolved-tree             unresolved-tree
                                    :overrides                   overrides
                                    :expositions                 expositions
-                                   :watermark                   watermark}
+                                   :watermark                   watermark
+                                   :report                      report}
               paths               {:src-path        (fs/file target-path "srcdeps" (u/sym->file-name pprefix))
                                    :parent-clj-dirs []
                                    :branch          []}]

--- a/src/mranderson/move.clj
+++ b/src/mranderson/move.clj
@@ -501,6 +501,54 @@
   (when (and (#{".clj" ".cljs"} extension) (.exists (sym->file source-path old-sym ".cljc")))
     (move-ns-file old-sym new-sym ".cljc" source-path)))
 
+(defn- file-rename-counts
+  "Counts, per rename, how many references in `content` the batch rewrite changes,
+  for run reporting. Mirrors `source-replacement-multi`'s dispatch (a repackaged
+  Java class is skipped; the longest-namespace prefix wins), so the tally matches
+  what the actual rewrite does. Returns `{old-sym ref-count}` for renames that
+  changed at least one reference."
+  [content renames java-classes]
+  (let [renames    (sort-by #(- (count (name (:old-sym %)))) renames)
+        by-segment (reduce (fn [m rename]
+                             (reduce #(update %1 %2 (fnil conj []) rename)
+                                     m (ns-first-segments (:old-sym rename))))
+                           {} renames)
+        regex      (re-pattern (str (->> renames
+                                         (map #(java.util.regex.Pattern/quote (load-param (:old-sym %))))
+                                         (str/join "|"))
+                                    "|"
+                                    (.pattern ^java.util.regex.Pattern symbol-regex)))]
+    (reduce (fn [counts match]
+              (let [candidates (get by-segment (token-first-segment match))]
+                (if (or (empty? candidates)
+                        (contains? java-classes (-> match (str/replace #"^[\"^]+" "") (str/replace #"\.$" ""))))
+                  counts
+                  (if-let [matched (some (fn [{:keys [old-sym new-sym] :as rename}]
+                                           (when (not= match (source-replacement old-sym new-sym match))
+                                             rename))
+                                         candidates)]
+                    (update counts (:old-sym matched) (fnil inc 0))
+                    counts))))
+            {}
+            (re-seq regex content))))
+
+(defn- rewrite-file!
+  "Applies the `applicable` renames to `file` in place (write skipped when nothing
+  changes). Returns nil when unchanged, otherwise a report map `{:file ...
+  :renames [{:old-sym :new-sym :refs n} ...]}` of the references rewritten."
+  [^File file applicable file-ext java-classes]
+  (let [old (slurp file)
+        new (str (replace-ns-symbols old applicable file-ext java-classes))]
+    (when (not= old new)
+      (spit file new)
+      (let [by-old (into {} (map (juxt :old-sym identity)) applicable)]
+        {:file    file
+         :renames (->> (file-rename-counts old applicable java-classes)
+                       (map (fn [[old-sym refs]]
+                              {:old-sym old-sym :new-sym (:new-sym (by-old old-sym)) :refs refs}))
+                       (sort-by (comp str :old-sym))
+                       vec)}))))
+
 (defn replace-ns-symbols-in-source-files
   "Applies a batch of namespace renames to every Clojure source file under
   `dirs`, reading and writing each file at most once (in parallel, per file).
@@ -512,7 +560,10 @@
   re-scanning the directories and re-reading every file once per rename.
 
   `java-classes` (optional) are fully-qualified repackaged Java class names that
-  the rewrite must leave untouched (they are prefixed by the java-import pass)."
+  the rewrite must leave untouched (they are prefixed by the java-import pass).
+
+  Returns a seq of per-file report maps for the files that changed (see
+  `rewrite-file!`), used by the run report (#43)."
   ([renames dirs]
    (replace-ns-symbols-in-source-files renames dirs #{}))
   ([renames dirs java-classes]
@@ -527,8 +578,9 @@
                      ;; this file (the per-rename behaviour of `update?`)
                      applicable (filterv #(update? (str file) (:extension %)) renames)]
                  (when (seq applicable)
-                   (update-file file (fn [content] (replace-ns-symbols content applicable file-ext java-classes)))))))
-            (doall))))))
+                   (rewrite-file! file applicable file-ext java-classes)))))
+            (doall)
+            (remove nil?))))))
 
 (defn replace-ns-symbol-in-source-files
   "Replaces all occurrences of `old-sym` with `new-sym` in every Clojure source

--- a/test/mranderson/core_test.clj
+++ b/test/mranderson/core_test.clj
@@ -492,3 +492,25 @@
         (let [out (with-out-str
                     (sut/print-deps-tree [] '[^:inline-dep [top "1"]] {:unresolved-tree true}))]
           (is (string/includes? out "  [nested \"2\"]")))))))
+
+;; ## #43 - run report
+
+(def ^:private print-run-report #'sut/print-run-report)
+
+(deftest t-print-run-report
+  (testing "lists each changed file with its renames and ref counts, relative to srcdeps"
+    (let [reports [{:file (io/file "/tmp/sd/myapp/core.clj")
+                    :renames [{:old-sym 'a.b :new-sym 'pre.a.b :refs 3}]}
+                   {:file (io/file "/tmp/sd/pre/a/b.clj")
+                    :renames [{:old-sym 'a.b :new-sym 'pre.a.b :refs 1}
+                              {:old-sym 'c.d :new-sym 'pre.c.d :refs 2}]}]
+          out     (with-out-str
+                    (print-run-report reports {:srcdeps "/tmp/sd" :pprefix "pre" :unresolved-tree false}))]
+      (is (string/includes? out "Inlined 2 file(s) under pre:"))
+      (is (string/includes? out "myapp/core.clj: a.b -> pre.a.b (3 refs)"))
+      (is (string/includes? out "pre/a/b.clj: c.d -> pre.c.d (2 refs)"))
+      (testing "singular ref wording"
+        (is (string/includes? out "pre/a/b.clj: a.b -> pre.a.b (1 ref)")))))
+  (testing "unresolved-tree mode reports that the run report is unavailable"
+    (let [out (with-out-str (print-run-report nil {:unresolved-tree true}))]
+      (is (string/includes? out "only available in resolved-tree mode")))))

--- a/test/mranderson/move_test.clj
+++ b/test/mranderson/move_test.clj
@@ -436,6 +436,21 @@
         (t/is (str/includes? out "#_[a.b Thing]"))
         (t/is (str/includes? out "[x.y Live]"))))))
 
+(def ^:private file-rename-counts #'sut/file-rename-counts)
+
+(t/deftest file-rename-counts-test
+  ;; #43: the run report counts references per rename, mirroring the real
+  ;; rewrite's dispatch.
+  (t/testing "counts refs per rename, longest namespace prefix winning"
+    (let [renames [{:old-sym 'a.b :new-sym 'x.y} {:old-sym 'a.b.c :new-sym 'x.y.c}]
+          content "(ns foo (:require [a.b :as b] [a.b.c :as c]))\n(a.b/go) (a.b/go) (a.b.c/stop)"]
+      (t/is (= {'a.b 3 'a.b.c 2} (file-rename-counts content renames #{})))))
+  (t/testing "a repackaged java class is skipped (left for the import pass), like the rewrite"
+    (let [renames [{:old-sym 'com.acme.impl :new-sym 'pre.com.acme.impl}]
+          content "(com.acme.impl.Widget. 1) com.acme.impl/foo"]
+      (t/is (= {'com.acme.impl 1} (file-rename-counts content renames #{"com.acme.impl.Widget"})))
+      (t/is (= {'com.acme.impl 2} (file-rename-counts content renames #{}))))))
+
 (t/deftest replace-ns-symbols-handles-already-inlined-sources
   ;; #39: MrAnderson can inline a library that was itself built by inlining its
   ;; deps (so it ships watermarked, already-prefixed namespaces). The watermark


### PR DESCRIPTION
Closes #43. Adds a `:report` option that, after inlining, prints a per-file summary of which namespaces' references were rewritten in each file and how many:

```
$ lein inline-deps :report true
...
Inlined 21 file(s) under myapp.inlined:
  myapp/core.clj: clojure.data.xml -> myapp.inlined.dataxml.v0v2v0-alpha6.clojure.data.xml (1 ref)
  myapp/inlined/dataxml/.../clojure/data/xml.clj: clojure.data.xml -> ...clojure.data.xml (3 refs)
  ...
```

The rewrite workers now return a per-file report alongside doing the rewrite. The ref counts mirror the real rewrite's dispatch: a repackaged Java class that's left for the java-import pass isn't counted, and the longest namespace prefix wins, so the numbers match what was actually changed.

Resolved-tree mode only (the default). Unresolved-tree mode rewrites per subtree and doesn't bubble up a report, so it prints a note instead. The whole thing is behind the opt-in `:report` flag, so default output is unchanged.

Tests cover the per-rename counting (including the java-class skip) and the report formatting; also smoke-tested end to end against a real dependency.

Fixes #43