### PR TITLE
Document that MrAnderson needs no Leiningen when used directly [#42]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 - [#34](https://github.com/benedekfazekas/mranderson/issues/34): Finalize the public API: `mranderson.core/inline-deps` is the supported entry point, `:source-paths` is now optional (omit it to shadow dependencies standalone, e.g. from the REPL), and the lower-level `mranderson.core/mranderson` and `copy-source-files` are marked `:no-doc` as internal
+- [#42](https://github.com/benedekfazekas/mranderson/issues/42): Document that the published artifact carries no Leiningen dependency, so MrAnderson can be used directly from tools.deps/tools.build with the lein task as an optional wrapper
 - [#65](https://github.com/benedekfazekas/mranderson/issues/65): Mark internal namespaces (`mranderson.util`, `mranderson.move`, `mranderson.dependency.*`) `:no-doc` so cljdoc documents only the public API (`mranderson.core`, `mranderson.plugin`, `leiningen.inline-deps`)
 - [#82](https://github.com/benedekfazekas/mranderson/issues/82): Centralize reader-discard handling in a new internal `mranderson.zloc` namespace that wraps rewrite-clj navigation, instead of scattering `:uneval` checks through `mranderson.move`
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ function is a plain, data-driven entry point that does the same work as the
 `lein inline-deps` task. It's handy when your project is built with
 [tools.build](https://clojure.org/guides/tools_build).
 
+The published artifact carries no Leiningen dependency - the `lein inline-deps`
+task and the `mranderson.plugin` middleware are an optional wrapper over the same
+engine, and `leiningen-core` is only a development dependency here. So adding
+`thomasa/mranderson` to a tools.deps build pulls in just the inlining engine (and
+`jarjar` for Java-class repackaging), not Leiningen.
+
 Add MrAnderson to a build alias in `deps.edn`:
 
 ```clojure


### PR DESCRIPTION
#42 wanted the lein plugin split into a separate, optional artifact, on the premise that `mranderson.util` still pulled in Leiningen for logging.

That premise is stale: `mranderson.util` logs via the standalone `mranderson.log`, and `leiningen-core` is only a `:dev` dependency. The published `thomasa/mranderson` artifact already carries no Leiningen dependency - a tools.deps/tools.build user gets the inlining engine plus `jarjar`, nothing else. So the issue's actual goal ("exclude leiningen when mranderson is used directly") is already met.

A literal artifact split would only remove a few inert namespaces from the engine jar, while forcing a breaking coordinate rename on one user cohort and reworking the self-hosting release flow. Not worth it. Instead this just makes the no-Leiningen story explicit in the README.

Fixes #42