### PR TITLE
Add a command-line interface [#35]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#35](https://github.com/benedekfazekas/mranderson/issues/35): Add a command-line interface, `mranderson.main`, that wraps `mranderson.core/inline-deps` so MrAnderson can be run without Leiningen: `clojure -M:mranderson -p com.example.inlined -s src org.clojure/tools.namespace:1.5.1`
+
 ## 0.7.0
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ REPL when you want to grab a library and shadow it on the fly:
 ;; => shadowed sources under target/srcdeps/repl/inlined/...
 ```
 
+### Command-line interface
+
+MrAnderson also ships a plain command-line entry point, `mranderson.main`, that
+takes the dependency coordinates to inline as positional arguments. Add it to a
+`deps.edn` alias:
+
+```clojure
+{:aliases
+ {:mranderson {:replace-deps {thomasa/mranderson {:mvn/version "0.7.0"}}
+               :main-opts    ["-m" "mranderson.main"]}}}
+```
+
+and run it:
+
+```
+clojure -M:mranderson -p com.example.inlined -s src \
+  org.clojure/tools.namespace:1.5.1 rewrite-clj:1.2.54
+```
+
+Coordinates are Maven-style (`group/artifact:version`). The options mirror
+`inline-deps`; run with `-h`/`--help` for the full list. As with `inline-deps`,
+`-s/--source-path` is optional - omit it to just shadow the given dependencies.
+
 ### Public API
 
 MrAnderson's supported, stable API is small:
@@ -138,6 +161,7 @@ MrAnderson's supported, stable API is small:
 - `mranderson.core/print-deps-tree` - print the dependency tree that would be
   inlined (also reachable via the `:print-deps-tree` option).
 - `mranderson.core/default-repositories` - the default Maven repositories.
+- `mranderson.main/-main` - the command-line entry point described above.
 - The `lein inline-deps` task (`leiningen.inline-deps`), a thin wrapper over
   `inline-deps`, and the `mranderson.plugin` middleware that backs it.
 

--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
                  ^:inline-dep [org.clojure/tools.namespace "1.5.1"]
                  ^:inline-dep [clj-commons/fs "1.6.312"]
                  ^:inline-dep [rewrite-clj "1.2.54"]
+                 ^:inline-dep [org.clojure/tools.cli "1.1.230"]
                  [org.clojure/clojure "1.10.3" :scope "provided"]
                  [org.pantsbuild/jarjar "1.7.2"]]
   :mranderson {:project-prefix "mranderson.inlined"}

--- a/src/mranderson/main.clj
+++ b/src/mranderson/main.clj
@@ -1,0 +1,96 @@
+(ns mranderson.main
+  "Command-line interface to MrAnderson. A thin wrapper over
+  `mranderson.core/inline-deps` so MrAnderson can be run directly, without
+  Leiningen - and, down the road, as a GraalVM native image (see #36).
+
+  Run it with the dependency coordinates to inline as positional arguments:
+
+      clojure -M -m mranderson.main -p com.example.inlined -s src \\
+        org.clojure/tools.namespace:1.5.1 rewrite-clj:1.2.54
+
+  No `:gen-class` here on purpose: it would make MrAnderson's own plugin AOT this
+  namespace during the self-inlining build. The native-image build (#36) will AOT
+  it in its own build context instead."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.tools.cli :as cli]
+            [mranderson.core :as core]))
+
+(def ^:private cli-options
+  [["-p" "--project-prefix PREFIX" "Namespace/path prefix for the shadowed deps (default: random)"]
+   ["-s" "--source-path PATH" "Project source dir to copy into srcdeps and rewrite (repeatable; omit to just shadow the deps)"
+    :multi true :default [] :default-desc "" :update-fn conj]
+   ["-t" "--target-path PATH" "Build target directory (default: target)"]
+   [nil "--unresolved-tree" "Use unresolved-tree mode (deeply nested isolation)"]
+   [nil "--skip-java-repackage" "Skip jarjar repackaging of bundled Java classes"]
+   [nil "--prefix-exclusions EDN" "EDN vector of import prefixes to leave untouched"
+    :parse-fn edn/read-string]
+   [nil "--watermark KW" "Metadata key stamped on inlined namespaces, or 'nil' to disable (default: :mranderson/inlined)"
+    :parse-fn (fn [s] (when-not (= "nil" s) (keyword (str/replace s #"^:" ""))))]
+   [nil "--print-deps-tree" "Print the dependency tree that would be inlined, then exit"]
+   [nil "--report" "After inlining, print a per-file report of what was rewritten"]
+   ["-h" "--help" "Print this help and exit"]])
+
+(defn- usage [summary]
+  (str/join
+   \newline
+   ["Usage: mranderson [options] coordinate..."
+    ""
+    "Inline and shadow the given dependency coordinates so they cannot interfere"
+    "with the dependencies of downstream consumers."
+    ""
+    "Coordinates are Maven-style: group/artifact:version (or artifact:version),"
+    "e.g. org.clojure/tools.namespace:1.5.1"
+    ""
+    "Options:"
+    summary]))
+
+(defn parse-coordinate
+  "Parses a `group/artifact:version` (or `artifact:version`) coordinate string
+  into a `[lib version]` vector. Throws on a string with no version segment."
+  [coord]
+  (let [idx (str/last-index-of coord ":")]
+    (when-not idx
+      (throw (ex-info (str "invalid coordinate (expected lib:version): " coord) {:coordinate coord})))
+    [(symbol (subs coord 0 idx)) (subs coord (inc idx))]))
+
+(defn options->opts
+  "Maps the parsed CLI `options` map and positional dependency `coords` to the
+  options map `mranderson.core/inline-deps` expects."
+  [options coords]
+  (cond-> {:dependencies (mapv parse-coordinate coords)}
+    (:project-prefix options)        (assoc :project-prefix (:project-prefix options))
+    (seq (:source-path options))     (assoc :source-paths (:source-path options))
+    (:target-path options)           (assoc :target-path (:target-path options))
+    (:unresolved-tree options)       (assoc :unresolved-tree true)
+    (:skip-java-repackage options)   (assoc :skip-repackage-java-classes true)
+    (contains? options :prefix-exclusions) (assoc :prefix-exclusions (:prefix-exclusions options))
+    (contains? options :watermark)   (assoc :watermark (:watermark options))
+    (:print-deps-tree options)       (assoc :print-deps-tree true)
+    (:report options)                (assoc :report true)))
+
+(defn -main [& args]
+  (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)]
+    (cond
+      (:help options)
+      (do (println (usage summary)) (System/exit 0))
+
+      errors
+      (binding [*out* *err*]
+        (doseq [e errors] (println e))
+        (println (usage summary))
+        (System/exit 1))
+
+      (empty? arguments)
+      (binding [*out* *err*]
+        (println "error: no dependency coordinates given")
+        (println (usage summary))
+        (System/exit 1))
+
+      :else
+      (try
+        (core/inline-deps (options->opts options arguments))
+        (System/exit 0)
+        (catch Exception e
+          (binding [*out* *err*] (println "error:" (.getMessage e)))
+          (System/exit 1))))))

--- a/test/mranderson/main_test.clj
+++ b/test/mranderson/main_test.clj
@@ -1,0 +1,53 @@
+(ns mranderson.main-test
+  (:require [mranderson.main :as sut]
+            [clojure.tools.cli :as cli]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest parse-coordinate-test
+  (testing "group/artifact:version"
+    (is (= ['org.clojure/tools.namespace "1.5.1"]
+           (sut/parse-coordinate "org.clojure/tools.namespace:1.5.1"))))
+  (testing "artifact:version (no group)"
+    (is (= ['rewrite-clj "1.2.54"] (sut/parse-coordinate "rewrite-clj:1.2.54"))))
+  (testing "only the last colon splits, so a version may not, but the lib may contain dots/slashes"
+    (is (= ['com.acme/lib "1.0.0"] (sut/parse-coordinate "com.acme/lib:1.0.0"))))
+  (testing "a coordinate without a version throws"
+    (is (thrown? clojure.lang.ExceptionInfo (sut/parse-coordinate "no-version")))))
+
+;; parse args the way -main does, so the tests exercise the real cli-options spec
+(def ^:private cli-options @#'sut/cli-options)
+
+(defn- parse [args]
+  (let [{:keys [options arguments]} (cli/parse-opts args cli-options)]
+    (sut/options->opts options arguments)))
+
+(deftest options->opts-test
+  (testing "flags and positional coordinates map onto inline-deps options"
+    (is (= {:dependencies '[[org.clojure/tools.namespace "1.5.1"] [rewrite-clj "1.2.54"]]
+            :project-prefix "com.example.inlined"
+            :source-paths ["src" "src-extra"]
+            :target-path "build"
+            :unresolved-tree true
+            :skip-repackage-java-classes true
+            :report true}
+           (parse ["-p" "com.example.inlined"
+                   "-s" "src" "-s" "src-extra"
+                   "-t" "build"
+                   "--unresolved-tree"
+                   "--skip-java-repackage"
+                   "--report"
+                   "org.clojure/tools.namespace:1.5.1"
+                   "rewrite-clj:1.2.54"]))))
+  (testing "minimal invocation: just coordinates, no source paths"
+    (is (= {:dependencies '[[org.clojure/data.xml "0.2.0-alpha6"]]}
+           (parse ["org.clojure/data.xml:0.2.0-alpha6"]))))
+  (testing "print-deps-tree flag"
+    (is (true? (:print-deps-tree (parse ["--print-deps-tree" "rewrite-clj:1.2.54"])))))
+  (testing "prefix-exclusions parses as EDN"
+    (is (= ["classlojure"] (:prefix-exclusions (parse ["--prefix-exclusions" "[\"classlojure\"]" "x:1"])))))
+  (testing "watermark keyword and the 'nil' disabling form"
+    (is (= :my/mark (:watermark (parse ["--watermark" ":my/mark" "x:1"]))))
+    (is (contains? (parse ["--watermark" "nil" "x:1"]) :watermark))
+    (is (nil? (:watermark (parse ["--watermark" "nil" "x:1"])))))
+  (testing "watermark is left to the inline-deps default when not given"
+    (is (not (contains? (parse ["x:1"]) :watermark)))))


### PR DESCRIPTION
Closes #35. Adds `mranderson.main`, a CLI wrapper over `mranderson.core/inline-deps`, so MrAnderson can run without Leiningen (and sets up the GraalVM native image, #36).

Dependency coordinates are positional (`group/artifact:version`); `--flags` mirror the `inline-deps` options, parsed with `org.clojure/tools.cli` (added as an inline-dep so the artifact stays self-contained).

```
clojure -M:mranderson -p com.example.inlined -s src \
  org.clojure/tools.namespace:1.5.1 rewrite-clj:1.2.54
```

Notes:
- No `:gen-class` on the namespace - it would get picked up by MrAnderson's own plugin (the `:gen-class` -> `:aot` path) and AOT-compiled during the self-inlining build, which fails. The native-image build (#36) will AOT `main` in its own context. Verified `make install` (the self-inline integration test) is green with the new inline-dep.
- Tests cover coordinate parsing and the flag -> options mapping; smoke-tested `--help`, `--print-deps-tree`, and the error path end to end.

Fixes #35