### PR TITLE
Integration tests: unresolved-tree golden + parallel downstream [#79]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        downstream: [cider-nrepl, refactor-nrepl]
     steps:
       - uses: actions/checkout@v4
 
@@ -133,6 +137,8 @@ jobs:
 
       # cider-nrepl/refactor-nrepl track moving upstream targets, so their builds
       # are informative but allowed to fail without turning the whole run red.
-      - name: Downstream integration (cider-nrepl, refactor-nrepl)
+      # One target per matrix job, so they run in parallel and failures are
+      # isolated to the offending library.
+      - name: Downstream integration (${{ matrix.downstream }})
         continue-on-error: true
-        run: scripts/downstream_test.sh
+        run: scripts/downstream_test.sh ${{ matrix.downstream }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - [#79](https://github.com/benedekfazekas/mranderson/issues/79): Rework the downstream integration tests to fetch pinned cider-nrepl/refactor-nrepl release sources instead of git submodules, repointed at the mranderson build under test (the submodules had drifted to an old pinned mranderson, so the test had stopped exercising local changes)
 - [#79](https://github.com/benedekfazekas/mranderson/issues/79): Add a golden-master test over the structure of generated inlining output (produced files and their rewritten namespaces) to catch unintended output changes
+- [#79](https://github.com/benedekfazekas/mranderson/issues/79): Cover unresolved-tree mode with its own golden fixture (the deeply nested layout), alongside the resolved-tree one
+- [#79](https://github.com/benedekfazekas/mranderson/issues/79): Run the two downstream integration libraries (cider-nrepl, refactor-nrepl) as parallel CI matrix jobs, so they run concurrently and a failure is isolated to the offending library
 
 ## 0.7.0
 

--- a/scripts/downstream_test.sh
+++ b/scripts/downstream_test.sh
@@ -2,8 +2,8 @@
 set -Eeuxo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
-# Build cider-nrepl and refactor-nrepl against the locally installed mranderson
-# and run their mrandersonized test suites.
+# Build cider-nrepl and/or refactor-nrepl against the locally installed
+# mranderson and run their mrandersonized test suites.
 #
 # We fetch pinned official release sources (instead of git submodules), so it's
 # clear exactly which release we test against, the sources live under target/
@@ -11,6 +11,9 @@ cd "$(git rev-parse --show-toplevel)"
 # in the repo. Each fetched project pins its own mranderson version, so we
 # rewrite it to the version we just built and installed - otherwise this would
 # silently test some old released mranderson instead of our changes.
+#
+# Pass one or more targets (cider-nrepl, refactor-nrepl) to run just those; with
+# no arguments it runs all of them. CI runs one target per (parallel) matrix job.
 #
 # Assumes `make install` has already installed mranderson to the local maven repo
 # (CI runs that as a separate, hard-failing step; `make integration-test` does it
@@ -23,30 +26,46 @@ REFACTOR_NREPL_VERSION="${REFACTOR_NREPL_VERSION:-3.13.0}"
 MRANDERSON_VERSION="$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?"' project.clj | head -1 | tr -d '"')"
 
 DOWNSTREAM_DIR="target/downstream"
-mkdir -p "$DOWNSTREAM_DIR"
 
 # Fetch a pinned release into target/ and repoint its mranderson plugin at the
 # version we just installed.
 fetch() {
   local name="$1" repo="$2" version="$3"
   local dir="$DOWNSTREAM_DIR/$name"
+  mkdir -p "$DOWNSTREAM_DIR"
   rm -rf "$dir"
   git clone --depth 1 --branch "v$version" "$repo" "$dir"
   sed -i.bak -E "s|(thomasa/mranderson) \"[^\"]*\"|\1 \"$MRANDERSON_VERSION\"|" "$dir/project.clj"
   rm -f "$dir/project.clj.bak"
 }
 
-fetch cider-nrepl    https://github.com/clojure-emacs/cider-nrepl.git    "$CIDER_NREPL_VERSION"
-fetch refactor-nrepl https://github.com/clojure-emacs/refactor-nrepl.git "$REFACTOR_NREPL_VERSION"
+test_cider_nrepl() {
+  fetch cider-nrepl https://github.com/clojure-emacs/cider-nrepl.git "$CIDER_NREPL_VERSION"
+  cd "$DOWNSTREAM_DIR/cider-nrepl"
+  # cider-nrepl observes CI, which triggers :pedantic?, which is irrelevant here:
+  unset CI
+  lein clean
+  lein with-profile -user,-dev inline-deps
+  lein with-profile -user,-dev,+1.10,+test,+plugin.mranderson/config test
+}
 
-# cider-nrepl observes CI, which triggers :pedantic?, which is irrelevant here:
-unset CI
+test_refactor_nrepl() {
+  fetch refactor-nrepl https://github.com/clojure-emacs/refactor-nrepl.git "$REFACTOR_NREPL_VERSION"
+  cd "$DOWNSTREAM_DIR/refactor-nrepl"
+  lein clean
+  make test
+}
 
-cd "$DOWNSTREAM_DIR/cider-nrepl"
-lein clean
-lein with-profile -user,-dev inline-deps
-lein with-profile -user,-dev,+1.10,+test,+plugin.mranderson/config test
+targets=("$@")
+if [ ${#targets[@]} -eq 0 ]; then
+  targets=(cider-nrepl refactor-nrepl)
+fi
 
-cd ../refactor-nrepl
-lein clean
-make test
+for target in "${targets[@]}"; do
+  # a subshell per target so each one's `cd` and `unset CI` stay isolated
+  case "$target" in
+    cider-nrepl)    (test_cider_nrepl) ;;
+    refactor-nrepl) (test_refactor_nrepl) ;;
+    *) echo "unknown downstream target: $target (expected cider-nrepl or refactor-nrepl)" >&2; exit 2 ;;
+  esac
+done

--- a/test-resources/golden/puget-1.0.2-unresolved.edn
+++ b/test-resources/golden/puget-1.0.2-unresolved.edn
@@ -1,0 +1,29 @@
+[{:path
+  "golden/inlined/puget/v1v0v2/arrangement/v1v1v1/arrangement/core.cljc",
+  :ns golden.inlined.puget.v1v0v2.arrangement.v1v1v1.arrangement.core}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/clojure.cljc",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.clojure}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/deque.cljc",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.deque}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/edn.cljc",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.edn}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/ednize.clj",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.ednize}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/ednize.cljs",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.ednize}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/engine.cljc",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.engine}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/repl.clj",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.repl}
+ {:path "golden/inlined/puget/v1v0v2/fipp/v0v6v10/fipp/visit.cljc",
+  :ns golden.inlined.puget.v1v0v2.fipp.v0v6v10.fipp.visit}
+ {:path "golden/inlined/puget/v1v0v2/puget/color.clj",
+  :ns golden.inlined.puget.v1v0v2.puget.color}
+ {:path "golden/inlined/puget/v1v0v2/puget/color/ansi.clj",
+  :ns golden.inlined.puget.v1v0v2.puget.color.ansi}
+ {:path "golden/inlined/puget/v1v0v2/puget/color/html.clj",
+  :ns golden.inlined.puget.v1v0v2.puget.color.html}
+ {:path "golden/inlined/puget/v1v0v2/puget/dispatch.clj",
+  :ns golden.inlined.puget.v1v0v2.puget.dispatch}
+ {:path "golden/inlined/puget/v1v0v2/puget/printer.clj",
+  :ns golden.inlined.puget.v1v0v2.puget.printer}]

--- a/test/mranderson/golden_test.clj
+++ b/test/mranderson/golden_test.clj
@@ -1,5 +1,5 @@
 (ns mranderson.golden-test
-  "Golden-master check on the *shape* of generated output (#79): for a pinned
+  "Golden-master checks on the *shape* of generated output (#79): for a pinned
   dependency inlined under a fixed prefix, the set of produced source files and
   the namespace each was rewritten to. Pinned deps + a fixed prefix make it
   deterministic, so any change in what MrAnderson emits - for instance from a
@@ -10,8 +10,12 @@
   perturbs, and it sidesteps the intra-file nondeterminism (e.g. metadata map
   ordering) that makes full-source diffing brittle.
 
-  If a change here is intentional, regenerate the golden with
-  `regenerate-golden!` below and commit the updated EDN."
+  There is a fixture for each inlining mode - resolved-tree (the flat default)
+  and unresolved-tree (the deeply nested layout, #79's part D) - so both code
+  paths are covered.
+
+  If a change here is intentional, regenerate the goldens with
+  `(regenerate-goldens!)` below and commit the updated EDN."
   (:require [mranderson.core :as core]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -19,16 +23,23 @@
             [clojure.pprint :as pp]
             [clojure.tools.namespace.file :refer [read-file-ns-decl]]
             [me.raynes.fs :as fs]
-            [clojure.test :refer [deftest is]])
+            [clojure.test :refer [deftest testing is]])
   (:import [java.io File]))
 
 (def ^:private golden-prefix "golden.inlined")
-(def ^:private golden-dep '[mvxcvi/puget "1.0.2"])
-(def ^:private golden-file "test-resources/golden/puget-1.0.2.edn")
 
 (def ^:private prefix-path
   ;; the prefix as a relative path, e.g. "golden/inlined"
   (str/replace golden-prefix "." "/"))
+
+(def ^:private fixtures
+  "Each fixture inlines a pinned dependency under `golden-prefix` and is checked
+  against `test-resources/golden/<name>.edn`."
+  [{:name "puget-1.0.2"            :dep '[mvxcvi/puget "1.0.2"] :opts {}}
+   {:name "puget-1.0.2-unresolved" :dep '[mvxcvi/puget "1.0.2"] :opts {:unresolved-tree true}}])
+
+(defn- golden-file [fixture]
+  (str "test-resources/golden/" (:name fixture) ".edn"))
 
 (defn- generated-structure
   "Walks the shadowed output under `srcdeps` (the `golden-prefix` subtree) and
@@ -45,28 +56,32 @@
        vec))
 
 (defn- inline-structure
-  "Inlines `golden-dep` under a fixed prefix into a fresh temp dir and returns
-  its generated structure, cleaning up afterwards."
-  []
+  "Inlines `fixture`'s dependency under the fixed prefix into a fresh temp dir and
+  returns its generated structure, cleaning up afterwards."
+  [{:keys [dep opts]}]
   (let [tmp (doto (File/createTempFile "mranderson-golden" "") (.delete) (.mkdirs))]
     (try
-      (core/inline-deps {:dependencies                [golden-dep]
-                         :project-prefix              golden-prefix
-                         :skip-repackage-java-classes true
-                         :target-path                 (str tmp)})
+      (core/inline-deps (merge {:dependencies                [dep]
+                                :project-prefix              golden-prefix
+                                :skip-repackage-java-classes true
+                                :target-path                 (str tmp)}
+                               opts))
       (generated-structure (io/file tmp "srcdeps"))
       (finally (fs/delete-dir tmp)))))
 
-(defn regenerate-golden!
-  "Rewrites the committed golden EDN from a fresh inlining run. Call from a REPL
+(defn regenerate-goldens!
+  "Rewrites every committed golden EDN from a fresh inlining run. Call from a REPL
   after an intentional change to MrAnderson's output, then commit the result."
   []
-  ;; compute the structure first (inlining logs to stdout), then capture only the
-  ;; pretty-printed EDN
-  (let [structure (inline-structure)]
-    (spit golden-file (with-out-str (pp/pprint structure)))))
+  (doseq [fixture fixtures]
+    ;; compute the structure first (inlining logs to stdout), then capture only
+    ;; the pretty-printed EDN
+    (let [structure (inline-structure fixture)]
+      (spit (golden-file fixture) (with-out-str (pp/pprint structure))))))
 
-(deftest puget-golden-test
-  (is (= (edn/read-string (slurp golden-file))
-         (inline-structure))
-      "generated output shape changed; if intentional, run (regenerate-golden!) and commit the updated golden"))
+(deftest golden-output-test
+  (doseq [{:keys [name] :as fixture} fixtures]
+    (testing name
+      (is (= (edn/read-string (slurp (golden-file fixture)))
+             (inline-structure fixture))
+          "generated output shape changed; if intentional, run (regenerate-goldens!) and commit the updated golden"))))


### PR DESCRIPTION
The remaining two asks from #79 (parts C and D), completing the issue's constructive scope (A and B landed in #132).

**D - unresolved-tree coverage.** Adds an unresolved-tree golden fixture (the deeply nested layout, e.g. `puget/v1v0v2/fipp/v0v6v10/...`) alongside the resolved-tree one. The golden test is now data-driven over a list of fixtures, so both inlining modes are golden-mastered. Verified deterministic.

**C - parallelize downstream.** Runs the two downstream libraries as parallel CI matrix jobs instead of one sequential step, so they run concurrently and a failure is isolated to the offending library. `downstream_test.sh` now takes an optional target (`cider-nrepl` / `refactor-nrepl`); with no args it still runs both. The known mranderson-user population is small (basically these two), so I kept the set at two rather than adding flaky extras - that's the honest answer to #79's "more libraries" musing.

Not touching #79's other musing ("maybe turf the unresolved-tree feature if unused") - that's a separate product decision, and this PR instead makes sure the mode stays covered.

53 tests/230 assertions green, eastwood + shellcheck clean.

Fixes #79